### PR TITLE
ci: use S3 streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -135,13 +135,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 4  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 4  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 40 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 8  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 40 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 8  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 40 } # max limit=375
-          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 20 } # max limit=500
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 80 } # max limit=375
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 40 } # max limit=500
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 30 --num-hepmc-events 15000 --minQ2 1    }
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 40 --num-hepmc-events 15000 --minQ2 10   }
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 50 --num-hepmc-events 15000 --minQ2 100  }
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 60 --num-hepmc-events 15000 --minQ2 1000 }
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -135,13 +135,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 150 --detector arches      }
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon } # NOTE: large RECO files
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 150 --detector arches      --radcor }
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon --radcor } # NOTE: large RECO files
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 4  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 4  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 375 }
-          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 500 }
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 40 } # max limit=375
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 20 } # max limit=500
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 10000 --minQ2 1    }
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 10000 --minQ2 10   }
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 10000 --minQ2 100  }
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 10000 --minQ2 1000 }
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 30 --num-hepmc-events 15000 --minQ2 1    }
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 40 --num-hepmc-events 15000 --minQ2 10   }
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 50 --num-hepmc-events 15000 --minQ2 100  }
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 60 --num-hepmc-events 15000 --minQ2 1000 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -135,13 +135,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --limit 20 --detector arches      }
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --limit 4  --detector brycecanyon } # NOTE: large RECO files
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --limit 20 --detector arches      --radcor }
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --limit 4  --detector brycecanyon --radcor } # NOTE: large RECO files
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 150 --detector arches      }
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon } # NOTE: large RECO files
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 150 --detector arches      --radcor }
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon --radcor } # NOTE: large RECO files
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --limit 40 }
-          - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 }
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 375 }
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 500 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -283,6 +283,9 @@ jobs:
           name: x_fullsim_${{matrix.detector}}
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: eic/run-cvmfs-osg-eic-shell@main
+        env:
+          S3_ACCESS_KEY: ${{secrets.S3_ACCESS_KEY}}
+          S3_SECRET_KEY: ${{secrets.S3_SECRET_KEY}}
         with:
           platform-release: "jug_xl:nightly"
           setup: environ.sh
@@ -293,7 +296,7 @@ jobs:
             echo "[CI] cat s3files.config"
             cat s3files.config
             echo "[CI] ANALYSIS MACRO"
-            ${{env.root_no_delphes}} 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config","${{matrix.detector}}.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
+            ${{env.root_no_delphes}} 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config","${{matrix.detector}}.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")' || echo "ignore failure"
       - uses: actions/upload-artifact@v3
         with:
           name: analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1}}    --num-hepmc-events 15000 --minQ2 1    }
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_10}}   --num-hepmc-events 15000 --minQ2 10   }
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_100}}  --num-hepmc-events 15000 --minQ2 100  }
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1000}} --num-hepmc-events 15000 --minQ2 1000 }
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_1}}"    --num-hepmc-events 15000 --minQ2 1    }
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_10}}"   --num-hepmc-events 15000 --minQ2 10   }
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_100}}"  --num-hepmc-events 15000 --minQ2 100  }
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_1000}}" --num-hepmc-events 15000 --minQ2 1000 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_1}}"    --num-hepmc-events 15000 --minQ2 1    }
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_10}}"   --num-hepmc-events 15000 --minQ2 10   }
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_100}}"  --num-hepmc-events 15000 --minQ2 100  }
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit "${{env.stat_fast_1000}}" --num-hepmc-events 15000 --minQ2 1000 }
+          - { id: 1,    options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1}}    --num-hepmc-events 15000 --minQ2 1    " }
+          - { id: 10,   options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_10}}   --num-hepmc-events 15000 --minQ2 10   " }
+          - { id: 100,  options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_100}}  --num-hepmc-events 15000 --minQ2 100  " }
+          - { id: 1000, options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1000}} --num-hepmc-events 15000 --minQ2 1000 " }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,28 @@ defaults:
     shell: bash
 
 env:
+  ### beam energies
   ebeam_en: 18
   pbeam_en: 275
+  ### statistics (normal test)
+  # stat_fast_1:    5
+  # stat_fast_10:   5
+  # stat_fast_100:  5
+  # stat_fast_1000: 5
+  # stat_epic_arches:      20
+  # stat_epic_brycecanyon: 4
+  # stat_ecce:   40
+  # stat_athena: 20
+  ### statistics (large)
+  stat_fast_1:    30
+  stat_fast_10:   40
+  stat_fast_100:  50
+  stat_fast_1000: 60
+  stat_epic_arches:      150
+  stat_epic_brycecanyon: 35
+  stat_ecce:   375
+  stat_athena: 500
+  ### ROOT wrappers
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -94,10 +114,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 1    } # 30
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 10   } # 40
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 100  } # 50
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 1000 } # 60
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1}}    --num-hepmc-events 15000 --minQ2 1    }
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_10}}   --num-hepmc-events 15000 --minQ2 10   }
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_100}}  --num-hepmc-events 15000 --minQ2 100  }
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1000}} --num-hepmc-events 15000 --minQ2 1000 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -135,13 +155,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 3 --detector arches      } # 150
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 3 --detector brycecanyon } # NOTE: large RECO files # 35
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 3 --detector arches      --radcor } # 150
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 3 --detector brycecanyon --radcor } # NOTE: large RECO files # 35
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      }
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon }
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      --radcor }
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon --radcor }
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 3 } # 375
-          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 3 } # 500
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit ${{env.stat_ecce}}   }
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit ${{env.stat_athena}} }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,8 @@ defaults:
     shell: bash
 
 env:
-  ### beam energies
   ebeam_en: 18
   pbeam_en: 275
-  ### statistics (normal test)
-  # stat_fast_1:    5
-  # stat_fast_10:   5
-  # stat_fast_100:  5
-  # stat_fast_1000: 5
-  # stat_epic_arches:      20
-  # stat_epic_brycecanyon: 4
-  # stat_ecce:   40
-  # stat_athena: 20
-  ### statistics (large)
-  stat_fast_1:    30
-  stat_fast_10:   40
-  stat_fast_100:  50
-  stat_fast_1000: 60
-  stat_epic_arches:      150
-  stat_epic_brycecanyon: 35
-  stat_ecce:   375
-  stat_athena: 500
-  ### ROOT wrappers
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -114,10 +94,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1}}    --num-hepmc-events 15000 --minQ2 1    " }
-          - { id: 10,   options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_10}}   --num-hepmc-events 15000 --minQ2 10   " }
-          - { id: 100,  options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_100}}  --num-hepmc-events 15000 --minQ2 100  " }
-          - { id: 1000, options: "--version hepmc.pythia6 --radcor --limit ${{env.stat_fast_1000}} --num-hepmc-events 15000 --minQ2 1000 " }
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 30 --num-hepmc-events 15000 --minQ2 1    }
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 40 --num-hepmc-events 15000 --minQ2 10   }
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 50 --num-hepmc-events 15000 --minQ2 100  }
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 60 --num-hepmc-events 15000 --minQ2 1000 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -155,13 +135,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: "--version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      " }
-          - { id: epic_brycecanyon,        options: "--version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon " }
-          - { id: epic_arches_radcor,      options: "--version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      --radcor " }
-          - { id: epic_brycecanyon_radcor, options: "--version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon --radcor " }
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 150 --detector arches      }
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon } # NOTE: large RECO files
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 150 --detector arches      --radcor }
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon --radcor } # NOTE: large RECO files
           # ECCE / ATHENA
-          - { id: ecce,   options: "--version ecce.22.1               --mode s --limit ${{env.stat_ecce}}   " }
-          - { id: athena, options: "--version athena.deathvalley-v1.0 --mode s --limit ${{env.stat_athena}} " }
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 375 }
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 500 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 30 --num-hepmc-events 15000 --minQ2 1    }
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 40 --num-hepmc-events 15000 --minQ2 10   }
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 50 --num-hepmc-events 15000 --minQ2 100  }
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 60 --num-hepmc-events 15000 --minQ2 1000 }
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 1    } # 30
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 10   } # 40
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 100  } # 50
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 3 --num-hepmc-events 15000 --minQ2 1000 } # 60
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -135,13 +135,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 150 --detector arches      }
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon } # NOTE: large RECO files
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 150 --detector arches      --radcor }
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 35  --detector brycecanyon --radcor } # NOTE: large RECO files
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 3 --detector arches      } # 150
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 3 --detector brycecanyon } # NOTE: large RECO files # 35
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 3 --detector arches      --radcor } # 150
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 3 --detector brycecanyon --radcor } # NOTE: large RECO files # 35
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 375 }
-          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 500 }
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 3 } # 375
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 3 } # 500
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -296,7 +296,7 @@ jobs:
             echo "[CI] cat s3files.config"
             cat s3files.config
             echo "[CI] ANALYSIS MACRO"
-            ${{env.root_no_delphes}} 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config","${{matrix.detector}}.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")' || echo "ignore failure"
+            ${{env.root_no_delphes}} 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config","${{matrix.detector}}.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
       - uses: actions/upload-artifact@v3
         with:
           name: analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      }
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon }
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      --radcor }
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon --radcor }
+          - { id: epic_arches,             options: "--version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      " }
+          - { id: epic_brycecanyon,        options: "--version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon " }
+          - { id: epic_arches_radcor,      options: "--version epic.22.11.3 --mode s --limit ${{env.stat_arches}}      --detector arches      --radcor " }
+          - { id: epic_brycecanyon_radcor, options: "--version epic.22.11.3 --mode s --limit ${{env.stat_brycecanyon}} --detector brycecanyon --radcor " }
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --mode s --limit ${{env.stat_ecce}}   }
-          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit ${{env.stat_athena}} }
+          - { id: ecce,   options: "--version ecce.22.1               --mode s --limit ${{env.stat_ecce}}   " }
+          - { id: athena, options: "--version athena.deathvalley-v1.0 --mode s --limit ${{env.stat_athena}} " }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 10 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
+          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
+          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
+          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
+          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -135,13 +135,13 @@ jobs:
       matrix:
         include:
           # EPIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 40 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 8  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 40 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 8  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --version epic.22.11.3 --mode s --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --mode s --limit 4  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --mode s --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --mode s --limit 4  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 80 } # max limit=375
-          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 40 } # max limit=500
+          - { id: ecce,   options: --version ecce.22.1               --mode s --limit 40 } # max limit=375
+          - { id: athena, options: --version athena.deathvalley-v1.0 --mode s --limit 20 } # max limit=500
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -34,7 +34,7 @@ void AnalysisAthena::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  chain->CanDeleteRefs();
+  // chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -34,7 +34,7 @@ void AnalysisAthena::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  // chain->CanDeleteRefs();
+  chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -34,6 +34,7 @@ void AnalysisAthena::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
+  chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -39,6 +39,7 @@ void AnalysisDelphes::Execute() {
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
+  chain->CanDeleteRefs();
   ExRootTreeReader *tr = new ExRootTreeReader(chain);
   ENT = tr->GetEntries();
   if(maxEvents>0) ENT = std::min(maxEvents,ENT);

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -39,7 +39,7 @@ void AnalysisDelphes::Execute() {
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  chain->CanDeleteRefs();
+  // chain->CanDeleteRefs();
   ExRootTreeReader *tr = new ExRootTreeReader(chain);
   ENT = tr->GetEntries();
   if(maxEvents>0) ENT = std::min(maxEvents,ENT);

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -39,7 +39,7 @@ void AnalysisDelphes::Execute() {
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  // chain->CanDeleteRefs();
+  chain->CanDeleteRefs();
   ExRootTreeReader *tr = new ExRootTreeReader(chain);
   ENT = tr->GetEntries();
   if(maxEvents>0) ENT = std::min(maxEvents,ENT);

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -35,7 +35,7 @@ void AnalysisEcce::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  chain->CanDeleteRefs();
+  // chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -35,7 +35,7 @@ void AnalysisEcce::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  // chain->CanDeleteRefs();
+  chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -35,6 +35,7 @@ void AnalysisEcce::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
+  chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -22,7 +22,7 @@ void AnalysisEpic::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  chain->CanDeleteRefs();
+  // chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -22,7 +22,7 @@ void AnalysisEpic::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
-  // chain->CanDeleteRefs();
+  chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -22,6 +22,7 @@ void AnalysisEpic::Execute()
       chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
     }
   }
+  chain->CanDeleteRefs();
 
   TTreeReader tr(chain);
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- minimize runner disk usage by streaming from S3 instead of downloading
- if we want, this allows us to maximize the statistics, since the limit becomes the 6 hour job limit, rather than the ~14GB runner disk space limit
- test statistics size and CI runtime remain the same

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no