### PR TITLE
test: verify `exit 13` does not occur when downloading from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EPIC-ANALYSIS
+## EPIC-ANALYSIS
 
 General purpose analysis software for (SI)DIS at the EIC
 


### PR DESCRIPTION
sanity check for #232 debugging

`exit 13` never really occurred in this way when downloading from S3 in the past; double check that is still the case today