### PR TITLE
feat: initial support for HPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ results*
 tutorial/*.config*
 get-files.sh
 *.xsec
+*.config.part
 valgrind.log
 
 # environment setup files

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ get-files.sh
 *.xsec
 *.config.part
 valgrind.log
+hpc/log
 
 # environment setup files
 external

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ release: FLAGS += -O3
 release: DEP_RECIPE = release
 release: clean all
 
-epic-analysis: deps epic-analysis-header $(PREFIX)/$(LIB)
+epic-analysis: deps epic-analysis-header $(PREFIX)/$(LIB) hpc
 	@echo "Done.\n"
 epic-analysis-header:
 	@echo "\n===== $(PROJECT) ====="
@@ -115,12 +115,6 @@ $(DICT): $(HEADERS) $(DEP_TARGETS)
 	$(ROOTCLING) -f $@ $(DEP_INCLUDES) $(HEADERS)
 	@mkdir -p $(PREFIX)
 	@mv src/$(PCM) $(PREFIX)/
-
-clean:
-	@echo "\n===== CLEAN $(PROJECT) ====="
-	$(RM) $(PREFIX)/$(LIB) $(PREFIX)/$(PCM) $(DICT)
-
-
 
 # dependency builds
 #################################################################
@@ -149,3 +143,27 @@ adage:
 adage-clean:
 	@echo "\n===== $@ ====="
 	$(MAKE) -C ${ADAGE_HOME} clean
+
+
+# HPC executables
+#################################################################
+
+HPC_SOURCES     := $(basename $(wildcard hpc/src/*.cpp))
+HPC_EXECUTABLES := $(addsuffix .exe, $(HPC_SOURCES))
+
+hpc: hpc-header $(HPC_EXECUTABLES)
+hpc-header:
+	@echo "\n===== HPC executables ====="
+hpc/src/%.exe: hpc/src/%.cpp $(PREFIX)/$(LIB)
+	@echo "----- build $@.o -----"
+	$(CXX) -c $< -o $@.o $(FLAGS) $(DEP_INCLUDES)
+	@echo "--- make executable $@"
+	$(CXX) -o $@ $@.o $(DEP_LIBRARIES) -L$(PREFIX) -l$(PROJECT)
+	$(RM) $@.o
+
+
+# clean
+#################################################################
+clean:
+	@echo "\n===== CLEAN $(PROJECT) ====="
+	$(RM) $(PREFIX)/$(LIB) $(PREFIX)/$(PCM) $(DICT) $(HPC_EXECUTABLES)

--- a/README.md
+++ b/README.md
@@ -135,23 +135,22 @@ Additional build options are available:
   simulation data are read
 
 
-## ATHENA Full Simulation
+## ePIC Full Simulation
 
 - Full simulation files are stored on S3; follow [s3tools documentation](s3tools/README.md)
   for scripts and guidance
 - In general, everything that can be done in fast simulation can also be done in
   full simulation; just replace your usage of `AnalysisDelphes` with
-  `AnalysisAthena`
+  `AnalysisEpic`
   - In practice, implementations may sometimes be a bit out of sync, where some
     features exist in fast simulation do not exist in full simulation, or vice
     versa
-- See the event loop in `src/AnalysisAthena.cxx` for details of how the full
+- See the event loop in `src/AnalysisEpic.cxx` for details of how the full
   simulation data are read
 
-## ECCE Full Simulation
+## ATHENA and ECCE Full Simulations
 
-- Similar implementation as ATHENA full simulation, but use `AnalysisEcce` to
-  read `EventEvaluator` output files
+- Similar implementation as ePIC full simulation, but use `AnalysisEcce` or `AnalysisAthena`
 
 ---
 
@@ -171,6 +170,9 @@ and follow the [README](tutorial/README.md).
   `epic-analysis` top directory, not from within their subdirectory, e.g., run
   `root -b -q tutorial/analysis_template.C`; this is because certain library
   and data directory paths are given as relative paths
+
+In general, these macros will run single-threaded. See [HPC documentation](hpc/README.md)
+for guidance how to run multi-threaded or on a High Performance Computing (HPC) cluster.
 
 ## Analysis Stage
 

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -6,9 +6,6 @@ job per simulation `ROOT` file. The scripts in this directory support this proce
 
 Run any script without any arguments for more documentation.
 
-Procedure
-=========
-
 ## 1. Preparation
 ```bash
 hpc/prepare.rb

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -6,6 +6,12 @@ job per simulation `ROOT` file. The scripts in this directory support this proce
 
 Run any script without any arguments for more documentation.
 
+**NOTE**: Running `epic-analysis` using these `hpc` tools is not as well tested as running
+single-threaded; please check everything carefully, especially Q2 weights. Report any
+issues; you are welcome to contribute your own scripts to support your preferred computing cluster.
+It is highly recommended to test jobs with small samples, before launching a full-scale analysis
+on all available data.
+
 ## 1. Preparation
 ```bash
 hpc/prepare.rb

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -1,0 +1,39 @@
+High Performance Computing (HPC) Support
+========================================
+
+To run jobs multi-threaded or on a computing cluster, `epic-analysis` can be configured to run one
+job per simulation `ROOT` file. The scripts in this directory support this procedure.
+
+Run any script without any arguments for more documentation.
+
+Procedure
+=========
+
+## 1. Preparation
+```bash
+hpc/prepare.rb
+```
+A typical `config` file will list several `ROOT` files; run `hpc/prepare.rb` to split a `config`
+file into one `config` file per `ROOT` file; these `config` files can each be fed to an analysis
+macro. Total yields per Q2 bin are automatically obtained and stored in all `config` files, to make
+sure the resulting Q2 weights are correct for the combined set of files.
+
+## 2. Run Jobs
+This step depends on where you want to run jobs. In general, output ROOT files will be written
+to a user-specified subdirectory of `out/`.
+
+### Local Condor
+```bash
+hpc/run-local-condor.rb
+```
+If you have a local `condor` service, use this script to prepare a `condor` configuration script.
+The user must then run `condor_submit` from outside of `eic-shell` (individual jobs will be run in `eic-shell`).
+Log files will be written to `hpc/log/`.
+
+## 3. Merge Output Files
+```bash
+hpc/merge.rb
+```
+After successfully running jobs, combine the resulting output `ROOT` files; this is basically `hadd`
+but with some handlers for our custom classes `Histos`, `BinSet`, etc. The resulting combined file
+can then be used in downstream post-processing macros or user analysis.

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -27,6 +27,14 @@ If you have a local `condor` service, use this script to prepare a `condor` conf
 The user must then run `condor_submit` from outside of `eic-shell` (individual jobs will be run in `eic-shell`).
 Log files will be written to `hpc/log/`.
 
+### RCF Cluster
+- TODO
+- Can we avoid using S3?
+
+### JLab Cluster
+- TODO - need Slurm config generator
+- Can we avoid using S3?
+
 ## 3. Merge Output Files
 ```bash
 hpc/merge.rb

--- a/hpc/merge.rb
+++ b/hpc/merge.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2023 Christopher Dilks
+
+# arguments
+outputBaseName = 'analysis'
+if ARGV.length < 1
+  puts """
+  USAGE:
+    #{$0} [output directory] [output basename (optional)]
+
+    - [output directory]: the output directory containing ROOT part files,
+                          which are assumed to be at: 
+
+                            [output directory]/parts/*.root
+
+    - [output basename]: optionally specify an output basename, so the output
+                         file name will be:
+
+                            [output directory]/[output basename].root
+                            
+                            default [output basename]: #{outputBaseName}
+
+    NOTE: for more control, run: hpc/src/merge_analysis_files.exe
+  """
+  exit 2
+end
+outputDir      = ARGV[0]
+outputBaseName = ARGV[1] if ARGV.length>1
+
+# run merge_analysis_files.exe
+partFileList   = Dir.glob "#{outputDir}/parts/*.root"  # get list of input part files
+outputFileName = "#{outputDir}/#{outputBaseName}.root" # set output file name
+system "hpc/src/merge_analysis_files.exe #{outputFileName} #{partFileList.join ' '}" # merge

--- a/hpc/prepare.rb
+++ b/hpc/prepare.rb
@@ -1,0 +1,121 @@
+#!/usr/bin/env ruby
+
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2023 Christopher Dilks
+
+require 'fileutils'
+
+# arguments
+if ARGV.length != 2
+  $stderr.puts """
+  USAGE: #{$0} [config_file] [directory_name]
+    - [config_file] will be split into several files, one
+      config file per ROOT file; the new files will be
+      written to [directory_name]
+  """
+  exit 2
+end
+ConfigFileN, OutDirN = ARGV
+
+# clean output directory
+puts "\nCleaning #{OutDirN} ..."
+FileUtils.mkdir_p OutDirN
+FileUtils.rm_f Dir.glob("#{OutDirN}/*config.part"), verbose: true
+
+
+# create config.template file, which we will use to generate config.part files
+# - the template file is a copy of the essential parts of the config file
+# - special strings that match the regex /__.*__/ will be modified when generating
+#   config.part files from the template
+templateFileN   = ConfigFileN + '.template'
+templateFile    = File.open templateFileN, 'w'
+configFileHash  = Hash.new
+numEventsHash   = Hash.new
+readingFileList = false
+rootFileNum     = 0
+q2key           = Proc.new{ configFileHash[':q2min'] + '_' + configFileHash[':q2max'] }
+puts "\nParsing #{ConfigFileN} and counting the number of events ..."
+File.open(ConfigFileN).readlines.each do |line_in|
+
+  # remove comments and newlines
+  line = line_in.gsub(/#.*/,'').chomp
+
+  # parse line: if key-value pair
+  if line.match? /^:/
+
+    # if already reading a list of ROOT files, reset some settings for this Q2 range
+    if readingFileList or configFileHash.size==0
+      configFileHash[':q2min']        = '1.0'
+      configFileHash[':q2max']        = '0.0'
+      configFileHash[':crossSection'] = '0.0'
+      templateFile.puts ":endGroup\n\n" if readingFileList
+      readingFileList = false
+    end
+
+    # add this key-value pair to the hash
+    key = line.split.first
+    val = line.split[1..-1].join ' '
+    configFileHash[key] = val
+
+    # add to config.template file
+    templateFile.puts line
+
+  # parse line: if a ROOT file, produce a new config.part file
+  elsif line.match? /\.root/
+    rootFile = line.split.first
+
+    # get the number of events in this ROOT file
+    if numEventsHash[q2key.call].nil?
+      numEventsHash[q2key.call] = {
+        :numEvents => 0,
+      }
+    end
+    puts "Counting events in #{rootFile}"
+    numEvents = `hpc/src/count_events.exe #{rootFile}`.chomp.to_i
+    numEventsHash[q2key.call][:numEvents] += numEvents
+    puts "  => #{numEvents} events"
+
+    # add template line for numEvents, if reading a new list of ROOT files
+    unless readingFileList
+      templateFile.puts "__numEvents__ #{q2key.call}"
+    end
+
+    # add ROOT file to template and prepare to parse the next line
+    templateFile.puts "__ROOT_#{rootFileNum}__ #{rootFile}"
+    readingFileList = true
+    rootFileNum += 1
+
+  end # end parsing
+end # end loop over config file lines
+templateFile.puts ":endGroup"
+templateFile.close
+
+
+# generate config.part files from the template
+puts "\nParsing #{templateFileN} to generate config.part files ..."
+rootFileNum.times do |i|
+
+  # start new config.part file
+  partFileN = OutDirN + '/' + File.basename(ConfigFileN).sub(/\.config$/,'') + ".%07d.config.part" % [i]
+  rootFile = 'ERROR: UNKNOWN'
+  File.open(partFileN,'w') do |partFile|
+
+    # parse template, and write to config.part file
+    File.open(templateFileN).readlines.each do |line|
+      if line.match? /^__numEvents__/
+        numEvents = numEventsHash[line.split.last][:numEvents]
+        line = ":numEvents #{numEvents}"
+      elsif line.match? /^__ROOT_#{i}__/
+        rootFile = line.split.last
+        line = rootFile
+      elsif line.match? /^__ROOT/
+        next
+      end
+      partFile.puts line
+    end
+
+  end
+  puts "#{partFileN} => #{rootFile}"
+
+end
+puts "\nDone. Config files written to #{OutDirN}/"

--- a/hpc/run-local-condor.rb
+++ b/hpc/run-local-condor.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 if ARGV.length < 3
   puts """
   USAGE:
-    #{$0} [analysis_macro] [directory of config.part files] [output directory] [additional macro args]...
+    #{$0} [analysis_macro] [directory of config.part files] [output subdirectory] [additional macro args]...
 
     - [analysis_macro]: the analysis ROOT macro to run on each file
                         NOTE: the first two arguments of the macro must be:
@@ -18,8 +18,9 @@ if ARGV.length < 3
 
     - [directory of config.part files]: directory containing config.part files to run
 
-    - [output directory]: output directory for resulting ROOT files
-                          NOTE: the ROOT files in this directory will be REMOVED
+    - [output subdirectory]: output subdirectory for resulting ROOT files
+                             NOTE: this will be a subdirectory of out/
+                             NOTE: the ROOT files in this directory will be REMOVED
 
     - [additional macro args]: all remaining arguments will be sent to the macro
                                NOTE: prepend strings with an underscore (_)
@@ -32,7 +33,7 @@ RootMacro, InDir, OutSubDir = ARGV[0..2]
 AdditionalArgs              = ARGV[3..-1]
 
 # set directories
-OutDir         = "#{OutSubDir}"
+OutDir         = "out/#{OutSubDir}"
 ShellScriptDir = "#{OutDir}/scripts"
 LogDir         = "hpc/log"
 LogSubDir      = "#{LogDir}/#{Time.now.to_i.to_s}" # use unix time for log subdirectory

--- a/hpc/run-local-condor.rb
+++ b/hpc/run-local-condor.rb
@@ -180,5 +180,10 @@ Monitor errors with:
 
   more #{LogSubDir}/*.err
 
+When condor jobs are done, merge the ROOT files by running
+(from inside eic-shell):
+
+  hpc/merge.rb #{OutDir}
+
 #{sep}
 """

--- a/hpc/run-local-condor.rb
+++ b/hpc/run-local-condor.rb
@@ -1,0 +1,169 @@
+#!/usr/bin/env ruby
+
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2023 Christopher Dilks
+
+require 'fileutils'
+
+# arguments
+if ARGV.length < 3
+  puts """
+  USAGE:
+    #{$0} [analysis_macro] [directory of config.part files] [output directory] [additional macro args]...
+
+    - [analysis_macro]: the analysis ROOT macro to run on each file
+                        NOTE: the first two arguments of the macro must be:
+                              - input config file
+                              - output file prefix
+
+    - [directory of config.part files]: directory containing config.part files to run
+
+    - [output directory]: output directory for resulting ROOT files
+                          NOTE: this is assumed to be a subdirectory of 'out/'
+                          NOTE: the ROOT files in this directory will be REMOVED
+
+    - [additional macro args]: all remaining arguments will be sent to the macro
+                               NOTE: prepend strings with an underscore (_)
+                                     to ensure they will have quotation marks in
+                                     the macro call
+  """
+  exit 2
+end
+RootMacro, InDir, OutSubDir = ARGV[0..2]
+AdditionalArgs              = ARGV[3..-1]
+
+# set directories
+OutDir         = "out/#{OutSubDir}"
+ShellScriptDir = "#{OutDir}/scripts"
+LogDir         = "hpc/log"
+LogSubDir      = "#{LogDir}/#{Time.now.to_i.to_s}" # use unix time for log subdirectory
+
+# glob config.part files
+partFileList = Dir.glob "#{InDir}/*.config.part"
+sep = '-'*50
+puts 'config.part files:', sep, partFileList, sep
+
+# make/clean directories
+puts "Cleaning #{OutDir} ..."
+FileUtils.mkdir_p OutDir
+FileUtils.rm_f    Dir.glob("#{OutDir}/*.root"), verbose: true
+FileUtils.rm_f    ShellScriptDir,               verbose: true
+FileUtils.mkdir_p ShellScriptDir,               verbose: true
+FileUtils.mkdir_p LogSubDir,                    verbose: true
+
+# add explicit quotes around string arguments
+def enquote(str)
+  "\"#{str}\""
+end
+RootMacroArgs = AdditionalArgs.map do |arg|
+  if arg.match? /^_/
+    enquote arg.sub(/^_/,'')
+  else
+    arg
+  end
+end
+
+# locate eic-shell # FIXME: this may not be correct for everyone!
+eicShellPrefix = ENV['EIC_SHELL_PREFIX']
+if eicShellPrefix.nil?
+  $stderr.puts "ERROR: unknown $EIC_SHELL_PREFIX, cannot find eic-shell"
+  exit 1
+end
+eicShell = eicShellPrefix.split('/')[0..-2].join('/') + '/eic-shell'
+
+# generate condor config
+condorConfigN = "#{OutDir}/run.condor"
+File.open(condorConfigN, 'w') do |condorConfig|
+
+  # header
+  condorConfig.puts """
+Executable   = #{eicShell}
+Universe     = vanilla
+notification = never
+getenv       = True"""
+
+  # loop over config.part files
+  partFileList.each do |partFile|
+
+    # get root file name from this config.part file
+    rootFile = File.open(partFile)
+      .readlines
+      .map(&:chomp)
+      .grep_v(/^:/)
+      .grep(/\.root$/)
+      .first
+    if rootFile.nil?
+      $sterr.puts "ERROR: cannot find ROOT file in #{partFile}"
+      next
+    end
+
+    # generate output file prefix
+    outFilePrefix = [
+      OutSubDir,
+      '/',
+      File.basename(partFile,'.config.part'),
+      '__',
+      File.basename(rootFile,'.root'),
+    ].join
+
+    # set ROOT macro arguments
+    macroArgs = [
+      enquote(partFile),
+      enquote(outFilePrefix),
+      *RootMacroArgs,
+    ].join(',')
+
+    # set log file name
+    logName = LogSubDir + '/' + File.basename(outFilePrefix)
+
+    # generate wrapper shell script; this is needed so we can run from outside eic-shell
+    shellScriptName = ShellScriptDir + '/make__' + File.basename(outFilePrefix) + '.sh'
+    File.open(shellScriptName,'w') do |script|
+      script.puts '#!/bin/bash'
+      script.puts """
+# call as: eic-shell -- #{shellScriptName}
+source environ.sh
+root -b -q #{RootMacro}'(#{macroArgs})'"""
+    end
+    FileUtils.chmod 'u+x', shellScriptName
+
+    # write job to condor config
+    condorConfig.puts """
+Arguments = -- #{shellScriptName}
+Log    = #{logName}.log
+Output = #{logName}.out
+Error  = #{logName}.err
+Queue"""
+
+  end # loop over config.part files
+end # close condorConfig file
+
+# print some things to check
+puts """
+#{sep}
+
+Sample shell script:
+#{sep}
+#{`cat #{Dir.glob("#{ShellScriptDir}/*.sh").first}`}
+#{sep}
+Assuming host eic-shell is: #{eicShell}
+... if this is incorrect, fix #{$0} (help needed) ...
+"""
+
+# print out what to do next
+puts """
+#{sep}
+Produced condor config file: #{condorConfigN}
+
+Make sure everything is correct, then submit jobs by running
+the following command from OUTSIDE of eic-shell:
+
+  condor_submit #{condorConfigN}
+
+Log files will be written to: #{LogSubDir}/
+Monitor errors with:
+
+  more #{LogSubDir}/*.err
+
+#{sep}
+"""

--- a/hpc/run-local-slurm.rb
+++ b/hpc/run-local-slurm.rb
@@ -1,0 +1,197 @@
+#!/usr/bin/env ruby
+
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2023 Christopher Dilks, Connor Pecar
+
+require 'fileutils'
+
+# arguments
+if ARGV.length < 3
+  puts """
+  USAGE:
+    #{$0} [analysis_macro] [directory of config.part files] [output subdirectory] [additional macro args]...
+
+    - [analysis_macro]: the analysis ROOT macro to run on each file
+                        NOTE: the first two arguments of the macro must be:
+                              - input config file
+                              - output file prefix
+
+    - [directory of config.part files]: directory containing config.part files to run
+
+    - [output subdirectory]: output subdirectory for resulting ROOT files
+                             NOTE: this will be a subdirectory of out/
+                             NOTE: the ROOT files in this directory will be REMOVED
+
+    - [additional macro args]: all remaining arguments will be sent to the macro
+                               NOTE: prepend strings with an underscore (_)
+                                     to ensure they will have quotation marks in
+                                     the macro call
+  """
+  exit 2
+end
+RootMacro, InDir, OutSubDir = ARGV[0..2]
+AdditionalArgs              = ARGV[3..-1]
+
+# set directories
+OutDir         = "out/#{OutSubDir}"
+ShellScriptDir = "#{OutDir}/scripts"
+LogDir         = "hpc/log"
+LogSubDir      = "#{LogDir}/#{Time.now.to_i.to_s}" # use unix time for log subdirectory
+
+# ask a yes/no question to the user
+def ask(question)
+  print "#{question}\n> "
+  answer = $stdin.gets.chomp.split('').first
+  return false if answer.nil?
+  answer.downcase == "y"
+end
+
+# make/clean directories
+cleanDirs = [
+  "#{OutDir}/parts",
+  ShellScriptDir,
+]
+puts "\nCleanup ...\nRemoving the following directories:"
+cleanDirs.each{ |dir| puts "- #{dir}" }
+correct = ask("\nIs this OK? [y/N]")
+puts "you answered " + (correct ? "yes" : "no; stopping!")
+exit unless correct
+cleanDirs.each do |dir|
+  FileUtils.rm_f    dir, verbose: true
+  FileUtils.mkdir_p dir, verbose: true
+end
+FileUtils.mkdir_p LogSubDir, verbose: true
+
+# glob config.part files
+partFileList = Dir.glob "#{InDir}/*.config.part"
+sep = '-'*50
+puts 'config.part files:', sep, partFileList, sep
+
+# add explicit quotes around string arguments
+def enquote(str)
+  "\"#{str}\""
+end
+RootMacroArgs = AdditionalArgs.map do |arg|
+  if arg.match? /^_/
+    enquote arg.sub(/^_/,'')
+  else
+    arg
+  end
+end
+
+# locate eic-shell # FIXME: this may not be correct for everyone!
+eicShellPrefix = ENV['EIC_SHELL_PREFIX']
+if eicShellPrefix.nil?
+  $stderr.puts "ERROR: unknown $EIC_SHELL_PREFIX, cannot find eic-shell"
+  exit 1
+end
+eicShell = eicShellPrefix.split('/')[0..-2].join('/') + '/eic-shell'
+
+# generate slurm config
+slurmConfigN = "#{OutDir}/scripts/run.slurm"
+commandListFile = "#{OutDir}/scripts/commandlist.slurm"
+File.open(slurmConfigN, 'w') do |slurmConfig|
+  File.open(commandListFile, 'w') do |commandList|
+    # header
+    slurmConfig.puts """#!/bin/bash
+#SBATCH --job-name=epic-analysis
+#SBATCH --account=eic
+#SBATCH --partition=production
+#SBATCH --mem-per-cpu=200
+#SBATCH --time=24:00:00"""
+    
+    # job array
+    nfiles = partFileList.count()
+    slurmConfig.puts """#SBATCH --array=1-#{nfiles}"""                  
+    # output
+    slurmConfig.puts """#SBATCH --output=#{OutDir}/log/%x-%j-%N.out
+#SBATCH --error=#{OutDir}/log/%x-%j-%N.err
+    """
+    # command
+    slurmConfig.puts """
+srun $(sed -n ${SLURM_ARRAY_TASK_ID}p #{commandListFile})
+"""
+
+    # loop over config.part files
+    partFileList.each do |partFile|
+
+      # get root file name from this config.part file
+      rootFile = File.open(partFile)
+                   .readlines
+                   .map(&:chomp)
+                   .grep_v(/^:/)
+                   .grep(/\.root$/)
+                   .first
+      if rootFile.nil?
+        $sterr.puts "ERROR: cannot find ROOT file in #{partFile}"
+        next
+      end
+
+      # generate output file prefix
+      outFilePrefix = [
+        "#{OutSubDir}/parts/",
+        File.basename(partFile,'.config.part'),
+        '__',
+        File.basename(rootFile,'.root'),
+      ].join
+
+      # set ROOT macro arguments
+      macroArgs = [
+        enquote(partFile),
+        enquote(outFilePrefix),
+        *RootMacroArgs,
+      ].join(',')
+
+      # set log file name
+      logName = LogSubDir + '/' + File.basename(outFilePrefix)
+
+      # generate wrapper shell script; this is needed so we can run from outside eic-shell
+      shellScriptName = ShellScriptDir + '/make__' + File.basename(outFilePrefix) + '.sh'
+      File.open(shellScriptName,'w') do |script|
+        script.puts '#!/bin/bash'
+        script.puts """
+# call as: eic-shell -- #{shellScriptName}
+source environ.sh
+root -b -q #{RootMacro}'(#{macroArgs})'"""
+      end
+      FileUtils.chmod 'u+x', shellScriptName
+      commandList.puts """#{eicShellPrefix}/eic-shell -- #{shellScriptName}
+"""
+    end # loop over config.part files
+  end # close slurm command list file
+end # close slurmConfig file
+
+# print some things to check
+puts """
+#{sep}
+
+Sample shell script:
+#{sep}
+#{`cat #{Dir.glob("#{ShellScriptDir}/*.sh").first}`}
+#{sep}
+Assuming host eic-shell is: #{eicShell}
+... if this is incorrect, fix #{$0} (help needed) ...
+"""
+
+# print out what to do next
+puts """
+#{sep}
+Produced slurm config file: #{slurmConfigN}
+
+Make sure everything is correct, then submit jobs by running
+the following command from OUTSIDE of eic-shell:
+
+  sbatch #{slurmConfigN}
+
+Log files will be written to: #{LogSubDir}/
+Monitor errors with:
+
+  more #{LogSubDir}/*.err
+
+When slurm jobs are done, merge the ROOT files by running
+(from inside eic-shell):
+
+  hpc/merge.rb #{OutDir}
+
+#{sep}
+"""

--- a/hpc/src/count_events.cpp
+++ b/hpc/src/count_events.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Christopher Dilks
+
+// count number of events in a given file
+
+#include <fmt/format.h>
+#include <TFile.h>
+#include <TTree.h>
+
+int main(int argc, char** argv) {
+  if(argc<=1) {
+    fmt::print(stderr,"USAGE: {} [root_file]\n",argv[0]);
+    return 2;
+  }
+
+  auto root_file_name = std::string(argv[1]);
+  auto root_file = TFile::Open(root_file_name.c_str());
+
+  if (root_file==nullptr || root_file->IsZombie()) {
+    fmt::print(stderr,"ERROR: Couldn't open input file '{}'\n",root_file_name);
+    return 1;
+  }
+
+  auto tree = root_file->Get<TTree>("Delphes");                   // fastsim
+  if(tree == nullptr) tree = root_file->Get<TTree>("events");     // EPIC, ATHENA
+  if(tree == nullptr) tree = root_file->Get<TTree>("event_tree"); // ECCE
+  if(tree == nullptr) {
+    fmt::print(stderr,"ERROR: Couldn't find tree in file '{}'\n",root_file_name);
+    return 1;
+  }
+
+  fmt::print("{}\n", tree->GetEntries());
+  root_file->Close();
+  return 0;
+}

--- a/hpc/src/count_events.cpp
+++ b/hpc/src/count_events.cpp
@@ -31,5 +31,6 @@ int main(int argc, char** argv) {
 
   fmt::print("{}\n", tree->GetEntries());
   root_file->Close();
+  delete root_file;
   return 0;
 }

--- a/hpc/src/merge_analysis_files.cpp
+++ b/hpc/src/merge_analysis_files.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Christopher Dilks
+
+// count number of events in a given file
+
+#include <fmt/format.h>
+#include <TSystem.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TKey.h>
+#include <TRegexp.h>
+#include <Histos.h>
+#include <adage/BinSet.h>
+
+int main(int argc, char** argv) {
+
+  // arguments
+  if(argc<=2) {
+    fmt::print(stderr,"USAGE: {} [output_root_file] [input_root_files]...\n",argv[0]);
+    fmt::print(stderr,"       (similar syntax as `hadd`)\n");
+    return 2;
+  }
+
+  // load dictionaries
+  gSystem->Load("libEpicAnalysis.so");
+
+  // get output file and list of input files
+  TString out_file_name(argv[1]);
+  std::vector<TString> in_file_names;
+  for(int i=2; i<argc; i++)
+    in_file_names.push_back(TString(argv[i]));
+  fmt::print("Running {}\n", argv[0]);
+  fmt::print("\n{:=<50}\n", "Input Files ");
+  for(auto in_file_name : in_file_names)
+    fmt::print("{}\n", in_file_name);
+  fmt::print("\n{:=<50}\n{}\n{:=<50}\n", "Output File ", out_file_name, "");
+
+  // TFile pointers
+  auto out_file = new TFile(out_file_name, "RECREATE");
+  std::vector<TFile*> in_files;
+  for(auto in_file_name : in_file_names)
+    in_files.push_back(new TFile(in_file_name));
+
+  // object maps
+  std::map<TString,TList*> in_trees;
+  std::map<TString,Histos*> in_histos;
+  std::map<TString,BinSet*> in_binsets;
+
+  // loop over input files
+  bool first_file = true;
+  for(auto in_file : in_files) {
+
+    // loop over input file's keys
+    TListIter nextKey(in_file->GetListOfKeys());
+    while(TKey * key = (TKey*) nextKey()) {
+      TString keyName(key->GetName());
+
+      // handle TTrees: add their pointers to lists `in_trees`
+      if(TString(key->GetClassName())=="TTree") {
+        auto obj = (TTree*) key->ReadObj(); 
+        if(first_file) {
+          fmt::print("Start list for TTree '{}'\n",keyName);
+          in_trees.insert({ keyName, new TList() });
+        }
+        try {
+          in_trees.at(keyName)->Add(obj);
+        } catch(const std::out_of_range& e) {
+          fmt::print(stderr,"ERROR: cannot find TTree '{}' in {}\n",keyName,in_file->GetName());
+        }
+      }
+
+      // if it's a directory of Histos histograms, ignore it since we will merge the Histos objects instead
+      else if(TString(key->GetClassName())=="TDirectoryFile" && keyName.Contains(TRegexp("^histArr_"))) {
+        // if(first_file) fmt::print("Skip Histos TDirectory {}\n",keyName);
+      }
+
+      // handle Histos objects: add all histograms to the first file's histograms
+      else if(TString(key->GetClassName())=="Histos") {
+        auto obj = (Histos*) key->ReadObj(); 
+        if(first_file) {
+          fmt::print("Read Histos '{}'\n",keyName);
+          in_histos.insert({ keyName, obj });
+        } else {
+          Histos *out_histos;
+          try {
+            out_histos = in_histos.at(keyName);
+            out_histos->AddHistos(obj);
+          } catch(const std::out_of_range& e) {
+            fmt::print(stderr,"ERROR: cannot find Histos '{}' in {}\n",keyName,in_file->GetName());
+          }
+        }
+      }
+
+      // handle BinSet objects: store the first file's BinSets; TODO: compare with all the others
+      else if(TString(key->GetClassName())=="BinSet") {
+        if(first_file) {
+          auto obj = (BinSet*) key->ReadObj(); 
+          fmt::print("Read BinSet '{}'\n",keyName);
+          in_binsets.insert({ keyName, obj });
+        }
+      }
+
+      // handle Weights // TODO
+      else if(
+          TString(key->GetClassName()).Contains(TRegexp("vector<.*>")) &&
+          ( keyName=="XsTotal" || keyName.Contains(TRegexp("^Weight.*Total$")) )
+          )
+      {
+        if(first_file)
+          fmt::print(stderr,"WARNING: merging of {} object named '{}' is not yet supported (TODO)\n",key->GetClassName(),keyName);
+      }
+
+      // unknown object
+      else {
+        if(first_file)
+          fmt::print(stderr,"WARNING: not sure how to handle {} object named '{}'. Ignoring.\n",key->GetClassName(),keyName);
+      }
+
+    } // end TKey loop
+    first_file = false;
+  } // end in_file loop
+
+  // focus to output directory
+  fmt::print("{:=<50}\n","");
+  out_file->cd();
+
+  // merge TTrees in `in_trees` and write
+  for(auto [name,list] : in_trees) {
+    fmt::print("Merging input trees for tree '{}'\n",name);
+    TTree::MergeTrees(list)->Write(name);
+  }
+
+  // write Histos objects
+  for(auto [name,histos] : in_histos) {
+    fmt::print("Writing Histos '{}'\n",name);
+    histos->WriteHists(out_file);
+  }
+  for(auto [name,histos] : in_histos)
+    histos->Write();
+  fmt::print(stderr,"WARNING: any Hist4D objects were not added, since Hist4D::Add must be implemented (TODO)\n");
+
+  // write BinSets
+  for(auto [name,binset] : in_binsets) {
+    fmt::print("Writing BinSet '{}'\n",name);
+    binset->Write(name);
+  }
+
+  // close files
+  for(auto in_file : in_files)
+    in_file->Close();
+  out_file->Close();
+
+  fmt::print("{:=<50}\n{} written.\n\n","",out_file_name);
+  return 0;
+}

--- a/src/Analysis.h
+++ b/src/Analysis.h
@@ -83,7 +83,7 @@ class Analysis
     // common cross section `xs`, and Q2 range `Q2min` to `Q2max`
     void AddFileGroup(
         std::vector<std::string> fileNames,
-        std::vector<Long64_t> entries,
+        Long64_t totalEntries,
         Double_t xs,
         Double_t Q2min,
         Double_t Q2max
@@ -133,7 +133,6 @@ class Analysis
 
     // setup / common settings
     std::vector<std::vector<std::string> > infiles;
-    std::vector<std::vector<Long64_t> > inEntries;
     // A lookup index for guessing which Q2 range an event belongs to.
     std::vector<std::size_t> inLookup;
     std::vector<Double_t> Q2xsecs;

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -30,8 +30,8 @@ void AnalysisAthena::Execute()
   auto chain = std::make_unique<TChain>("events");
   for(Int_t idx=0; idx<infiles.size(); ++idx) {
     for(std::size_t idxF=0; idxF<infiles[idx].size(); ++idxF) {
-      // std::cout << "Adding " << infiles[idx][idxF] << " with " << inEntries[idx][idxF] << std::endl;
-      chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
+      // std::cout << "Adding " << infiles[idx][idxF] << std::endl;
+      chain->Add(infiles[idx][idxF].c_str());
     }
   }
   chain->CanDeleteRefs();

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -35,8 +35,8 @@ void AnalysisDelphes::Execute() {
   auto chain = std::make_unique<TChain>("Delphes");
   for(Int_t idx=0; idx<infiles.size(); ++idx) {
     for(std::size_t idxF=0; idxF<infiles[idx].size(); ++idxF) {
-      // std::cout << "Adding " << infiles[idx][idxF] << " with " << inEntries[idx][idxF] << std::endl;
-      chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
+      // std::cout << "Adding " << infiles[idx][idxF] << std::endl;
+      chain->Add(infiles[idx][idxF].c_str());
     }
   }
   chain->CanDeleteRefs();

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -31,8 +31,8 @@ void AnalysisEcce::Execute()
   auto chain = std::make_unique<TChain>("event_tree");
   for(Int_t idx=0; idx<infiles.size(); ++idx) {
     for(std::size_t idxF=0; idxF<infiles[idx].size(); ++idxF) {
-      // std::cout << "Adding " << infiles[idx][idxF] << " with " << inEntries[idx][idxF] << std::endl;
-      chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
+      // std::cout << "Adding " << infiles[idx][idxF] << std::endl;
+      chain->Add(infiles[idx][idxF].c_str());
     }
   }
   chain->CanDeleteRefs();

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -18,8 +18,8 @@ void AnalysisEpic::Execute()
   auto chain = std::make_unique<TChain>("events");
   for(Int_t idx=0; idx<infiles.size(); ++idx) {
     for(std::size_t idxF=0; idxF<infiles[idx].size(); ++idxF) {
-      // std::cout << "Adding " << infiles[idx][idxF] << " with " << inEntries[idx][idxF] << std::endl;
-      chain->Add(infiles[idx][idxF].c_str(), inEntries[idx][idxF]);
+      // std::cout << "Adding " << infiles[idx][idxF] << std::endl;
+      chain->Add(infiles[idx][idxF].c_str());
     }
   }
   chain->CanDeleteRefs();

--- a/src/Histos.cxx
+++ b/src/Histos.cxx
@@ -253,6 +253,19 @@ CutDef *Histos::GetCutDef(TString varName) {
   return nullptr;
 };
 
+// add histograms of `in_histos` to histograms in `this`
+void Histos::AddHistos(Histos *in_histos) {
+  for(auto [key,this_hist] : histMap) {
+    auto in_hist = in_histos->Hist(key);
+    if(in_hist==nullptr) continue;
+    this_hist->Add(in_hist);
+  }
+  // for(auto [key,this_hist] : hist4Map) {
+  //   auto in_hist = in_histos->Hist4(key);
+  //   if(in_hist==nullptr) continue;
+  //   this_hist->Add(in_hist); // TODO: no add method
+  // }
+}
 
 Histos::~Histos() {
   for(auto it : CutDefList)

--- a/src/Histos.h
+++ b/src/Histos.h
@@ -133,6 +133,9 @@ class Histos : public TNamed
       ofile->cd("/");
     };
 
+    // add histograms of `in_histos` to histograms in `this`
+    void AddHistos(Histos *in_histos);
+
     // fill a histogram, iff it is defined
     template <typename... VALS> void FillHist1D(TString histName, VALS... values) {
       auto hist = Hist(histName,true);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Prepare for running jobs on HPC clusters. The idea is a 3 step procedure: 
1. `hpc/prepare.rb`: split a config file into one config file per ROOT file; these config files can be fed to `Analysis`; total yields per Q2 bin are automatically obtained and stored in all config files, to make sure the resulting Q2 weights are correct for the combined set of files. See #235 for details
2. `hpc/run-local-condor.rb`: prepare a `condor` configuration script to run these config files locally on `condor`; the user must run `condor_submit` externally from `eic-shell` (but jobs will be run in an `eic-shell` instance); this type of script could be extended to support HPC clusters
3. `hpc/merge.rb`: combine the resulting output ROOT files; this is basically `hadd` with some handlers for our custom classes `Histos`, `BinSet`, etc. Resolves #20

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__) close #235 and #20
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [x] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no