### PR TITLE
fix: `delete` any `TFile` pointer created by `TFile::Open()`

### DIFF
--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -204,6 +204,7 @@ void Analysis::Prepare() {
       }
       else entries.push_back(tree->GetEntries());
       file->Close();
+      delete file;
     }
     // add the file group
     AddFileGroup(fileNames, entries, xsec, Q2min, Q2max);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Any `TFile` which is opened with `TFile::Open()` will create a pointer that will not be automatically deleted, does not like to be wrapped by a smart pointer, and may not be fully closed by `TFile::Close()` when streaming from S3. 

Thanks to @rseidl-rcf for finding and fixing this bug!

Hopefully this resolves our `exit 13` mystery in #232 

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no