### PR TITLE
fix: make `pybind` inclusion optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ DEP_LIBRARIES = $(shell root-config --glibs)
 # Data Model (PODIO + EDM4hep + EDM4eic)
 DEP_LIBRARIES += -L/usr/local/lib -lpodio -lpodioRootIO -ledm4hep -ledm4eic
 
-# PYTHON (for pybind)
-DEP_LIBRARIES += -lpython3.10
-
 # Miscellaneous
 DEP_LIBRARIES += -lfmt
 

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -35,11 +35,13 @@
 #endif
 #endif
 // pybind (for ML models using python packages)
+#ifdef SIDIS_MLPRED
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
 namespace py = pybind11;
+#endif
 
 using std::map;
 using std::cout;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Some `pybind` headers were still included in `Kinematics.h`; this PR ensures macro `SIDIS_MLPRED` controls their inclusion.

Fixes runtime error: https://github.com/eic/epic-analysis/actions/runs/4346053472/jobs/7591698317

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @cpecar 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no