### PR TITLE
feat: support productions `23.01` and `23.03`

### DIFF
--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 
 # default CLI options
 options = OpenStruct.new
-options.version    = 'epic.22.11.3'
+options.version    = 'epic.23.03.0'
 options.energy     = '18x275'
 options.locDir     = ''
 options.mode       = 's'
@@ -43,6 +43,31 @@ end
 #   :fileExtension   => File extension (optional, defaults to 'root')
 # }
 prodSettings = {
+  'epic.23.03.0' => {
+    :comment         => 'Pythia 6, with & without radiative corrections',
+    :crossSectionID  => Proc.new { |minQ2,maxQ2,radDir| "pythia6:ep_#{radDir}.#{options.energy}_q2_#{minQ2}_#{maxQ2}" },
+    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/SIDIS/pythia6" },
+    :energySubDir    => Proc.new { "ep_#{options.energy}" },
+    :dataSubDir      => Proc.new { |radDir|
+      # if [options.energy,radDir]==['18x275','noradcor']  # correct for S3 disorganization  #FIXME: still true?
+      #   "hepmc_ip6"
+      # else
+        "hepmc_ip6/#{radDir}"
+      # end
+    },
+    #
+    #
+    # FIXME: are there also Pythia8 data in this production ?!?!?!?
+    #
+    #
+  },
+  'epic.23.01.0' => {
+    :comment         => 'Pythia 8',
+    :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
+    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
+    :energySubDir    => Proc.new { "#{options.energy}" },
+    :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
+  },
   'epic.22.11.3' => {
     :comment         => 'Pythia 6, with & without radiative corrections',
     :crossSectionID  => Proc.new { |minQ2,maxQ2,radDir| "pythia6:ep_#{radDir}.#{options.energy}_q2_#{minQ2}_#{maxQ2}" },
@@ -292,6 +317,7 @@ end
 
 # pattern: "ep_#{energy}/hepmc_ip6/" with Q2 range given in file name as "q2_#{minQ2}_#{maxQ2}"
 if [
+    'epic.23.03.0',
     'epic.22.11.3',
     'hepmc.pythia6',
 ].include? options.version
@@ -333,6 +359,7 @@ if [
 
 # pattern: "#{energy}/minQ2=#{minQ2}/"
 elsif [
+  'epic.23.01.0',
   'epic.22.11.2',
   'athena.deathvalley-v1.0',
   'hepmc.pythia8',

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -27,7 +27,10 @@ HostURL           = 'https://eics3.sdcc.bnl.gov:9000'
 
 # helpers
 def versionNum(v) # options.version -> version number
-  v.split('.')[1..-1].join('.')
+  v
+    .split('_').first
+    .split('.')[1..-1]
+    .join('.')
 end
 def ecceQ2range(minQ2,maxQ2) # return file path suffix, for ECCE Q2 ranges
   { [1,0]=>'', [1,100]=>'-q2-low', [100,0]=>'-q2-high' }[[minQ2,maxQ2]]
@@ -43,23 +46,19 @@ end
 #   :fileExtension   => File extension (optional, defaults to 'root')
 # }
 prodSettings = {
-  'epic.23.03.0' => {
-    :comment         => 'Pythia 6, with & without radiative corrections',
+  'epic.23.03.0_pythia8' => {
+    :comment         => 'Pythia 8, small sample, 10x100, minQ2=1000 only',
+    :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
+    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
+    :energySubDir    => Proc.new { "#{options.energy}" },
+    :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
+  },
+  'epic.23.03.0_pythia6' => {
+    :comment         => 'Pythia 6, small sample, 5x41, noradcor only',
     :crossSectionID  => Proc.new { |minQ2,maxQ2,radDir| "pythia6:ep_#{radDir}.#{options.energy}_q2_#{minQ2}_#{maxQ2}" },
     :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/SIDIS/pythia6" },
     :energySubDir    => Proc.new { "ep_#{options.energy}" },
-    :dataSubDir      => Proc.new { |radDir|
-      # if [options.energy,radDir]==['18x275','noradcor']  # correct for S3 disorganization  #FIXME: still true?
-      #   "hepmc_ip6"
-      # else
-        "hepmc_ip6/#{radDir}"
-      # end
-    },
-    #
-    #
-    # FIXME: are there also Pythia8 data in this production ?!?!?!?
-    #
-    #
+    :dataSubDir      => Proc.new { |radDir| "hepmc_ip6/#{radDir}" },
   },
   'epic.23.01.0' => {
     :comment         => 'Pythia 8',
@@ -317,7 +316,7 @@ end
 
 # pattern: "ep_#{energy}/hepmc_ip6/" with Q2 range given in file name as "q2_#{minQ2}_#{maxQ2}"
 if [
-    'epic.23.03.0',
+    'epic.23.03.0_pythia6',
     'epic.22.11.3',
     'hepmc.pythia6',
 ].include? options.version
@@ -359,6 +358,7 @@ if [
 
 # pattern: "#{energy}/minQ2=#{minQ2}/"
 elsif [
+  'epic.23.03.0_pythia8',
   'epic.23.01.0',
   'epic.22.11.2',
   'athena.deathvalley-v1.0',

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 
 # default CLI options
 options = OpenStruct.new
-options.version    = 'epic.23.03.0'
+options.version    = 'epic.22.11.3'
 options.energy     = '18x275'
 options.locDir     = ''
 options.mode       = 's'

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -53,13 +53,13 @@ prodSettings = {
     :energySubDir    => Proc.new { "#{options.energy}" },
     :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
   },
-  'epic.23.03.0_pythia6' => {
-    :comment         => 'Pythia 6, small sample, 5x41, noradcor only',
-    :crossSectionID  => Proc.new { |minQ2,maxQ2,radDir| "pythia6:ep_#{radDir}.#{options.energy}_q2_#{minQ2}_#{maxQ2}" },
-    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/SIDIS/pythia6" },
-    :energySubDir    => Proc.new { "ep_#{options.energy}" },
-    :dataSubDir      => Proc.new { |radDir| "hepmc_ip6/#{radDir}" },
-  },
+  # 'epic.23.03.0_pythia6' => { # FIXME: need cross section for Q2<1 bin
+  #   :comment         => 'Pythia 6, small sample, 5x41, noradcor only, Q2<1 only',
+  #   :crossSectionID  => Proc.new { |minQ2,maxQ2,radDir| "pythia6:ep_#{radDir}.#{options.energy}_q2_#{minQ2}_#{maxQ2}" },
+  #   :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/SIDIS/pythia6" },
+  #   :energySubDir    => Proc.new { "ep_#{options.energy}" },
+  #   :dataSubDir      => Proc.new { |radDir| "hepmc_ip6/#{radDir}" },
+  # },
   'epic.23.01.0' => {
     :comment         => 'Pythia 8',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`s3tool` support for latest 2023 production versions.

Newer productions may not have as much data as older versions, so leaving the default production version as is: `22.11.3`. Use `s3tool.rb -v` to try later versions.

Tests:
- [x] https://github.com/eic/epic-analysis/pull/264
- [x] https://github.com/eic/epic-analysis/pull/265
- [x] https://github.com/eic/epic-analysis/pull/266

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no