### PR TITLE
build: make build with `PODIO` optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ DEP_LIBRARIES = $(shell root-config --glibs)
 #DEP_LIBRARIES += -lMinuit -lRooFitCore -lRooFit -lRooStats -lProof -lMathMore
 
 # Data Model (PODIO + EDM4hep + EDM4eic)
-DEP_LIBRARIES += -L/usr/local/lib -lpodio -lpodioRootIO -ledm4hep -ledm4eic
+DEP_LIBRARIES += -L/usr/local/lib -ledm4hep -ledm4eic
+ifdef INCLUDE_PODIO
+	DEP_LIBRARIES += -L/usr/local/lib -lpodio -lpodioRootIO
+	FLAGS += -DINCLUDE_PODIO
+endif
 
 # Miscellaneous
 DEP_LIBRARIES += -lfmt

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Additional build options are available:
 ```bash
 INCLUDE_CENTAURO=1 make  # build with fastjet plugin Centauro (not included in Delphes by default!)
 EXCLUDE_DELPHES=1 make   # build without Delphes support; primarily used to expedite CI workflows
+INCLUDE_PODIO=1 make     # build with support for reading data with PODIO
 ```
 
 ## Quick Start: Tutorial Macros

--- a/src/AnalysisEpicPodio.cxx
+++ b/src/AnalysisEpicPodio.cxx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Christopher Dilks
+#ifdef INCLUDE_PODIO
 
 #include "AnalysisEpicPodio.h"
 
@@ -465,3 +466,4 @@ int AnalysisEpicPodio::GetReconstructedPDG(
   return pdg;
 }
 
+#endif

--- a/src/AnalysisEpicPodio.h
+++ b/src/AnalysisEpicPodio.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Christopher Dilks
+#ifdef INCLUDE_PODIO
 
 #pragma once
 
@@ -68,3 +69,5 @@ class AnalysisEpicPodio : public Analysis
 
     ClassDefOverride(AnalysisEpicPodio,1);
 };
+
+#endif

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -32,9 +32,13 @@
 // analysis event loop classes
 #pragma link C++ class Analysis+;
 #pragma link C++ class AnalysisEpic+;
-#pragma link C++ class AnalysisEpicPodio+;
 #pragma link C++ class AnalysisAthena+;
 #pragma link C++ class AnalysisEcce+;
+
+#ifdef INCLUDE_PODIO
+#pragma link C++ class AnalysisEpicPodio+;
+#endif
+
 #ifndef EXCLUDE_DELPHES
 #pragma link C++ class AnalysisDelphes+;
 #endif

--- a/tutorial/podio_datatypes.C
+++ b/tutorial/podio_datatypes.C
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2022 Christopher Dilks
 
+//////////////////////////////////////////////////////
+//
+// FIXME: this needs to be updated for PODIO Frames
+//
+//////////////////////////////////////////////////////
+
 // print PODIO data types for a ROOT file
 //
 // USAGE:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This removes the `EventStore` deprecation warnings, until we can full transition to PODIO frames. PODIO support will now be disabled by default.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no