### PR TITLE
ci: use `--no-radcor` for fastsim tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: 1,    options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
-          - { id: 10,   options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
-          - { id: 100,  options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
-          - { id: 1000, options: --version hepmc.pythia6 --radcor --limit 5 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
+          - { id: 1,    options: --version hepmc.pythia6 --no-radcor --limit 5 --num-hepmc-events 15000 --minQ2 1    } # max limit=30
+          - { id: 10,   options: --version hepmc.pythia6 --no-radcor --limit 5 --num-hepmc-events 15000 --minQ2 10   } # max limit=40
+          - { id: 100,  options: --version hepmc.pythia6 --no-radcor --limit 5 --num-hepmc-events 15000 --minQ2 100  } # max limit=50
+          - { id: 1000, options: --version hepmc.pythia6 --no-radcor --limit 5 --num-hepmc-events 15000 --minQ2 1000 } # max limit=60
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,17 +554,17 @@ jobs:
             echo "yvar = ${{matrix.yvar}}"
             echo "[CI] COMPARATOR MACRO: ePIC"
             macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-              'ePIC Arches'               'epic_arches'             \
-              'ePIC BryceCanyon'          'epic_brycecanyon'        \
-              'ePIC Arches (radcor)'      'epic_arches_radcor'      \
-              'ePIC BryceCanyon (radcor)' 'epic_brycecanyon_radcor' \
+              'ePIC Arches (no radcor)'      'epic_arches'             \
+              'ePIC BryceCanyon (no radcor)' 'epic_brycecanyon'        \
+              'ePIC Arches (radcor)'         'epic_arches_radcor'      \
+              'ePIC BryceCanyon (radcor)'    'epic_brycecanyon_radcor' \
               'ePIC'
             echo "[CI] COMPARATOR MACRO: LEGACY"
             macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-              'Delphes Pythia6 (radcor)' 'fastsim'            \
-              'ePIC Arches (radcor)'     'epic_arches_radcor' \
-              'ATHENA'                   'athena'             \
-              'ECCE'                     'ecce'               \
+              'Delphes Pythia6 (no radcor)' 'fastsim'     \
+              'ePIC Arches (no radcor)'     'epic_arches' \
+              'ATHENA'                      'athena'      \
+              'ECCE'                        'ecce'        \
               'LEGACY'
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Use non-radiative-corrected data for fast simulation CI tests (because of https://github.com/eic/epic-analysis/issues/248)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no