### PR TITLE
feat: add `epic.unstable` testing version to `s3tool.rb`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 10
-  pbeam_en: 100
+  ebeam_en: 18
+  pbeam_en: 275
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --version epic.unstable --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.unstable --limit 4  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.unstable --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.unstable --limit 4  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --version epic.22.11.3 --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --limit 4  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --limit 4  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 18
-  pbeam_en: 275
+  ebeam_en: 10
+  pbeam_en: 100
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --limit 4  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --limit 4  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --version epic.unstable --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.unstable --limit 4  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.unstable --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.unstable --limit 4  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -46,6 +46,13 @@ end
 #   :fileExtension   => File extension (optional, defaults to 'root')
 # }
 prodSettings = {
+  'epic.unstable' => {
+    :comment         => "Latest ePIC TEST sample production; update in #{$0} as needed",
+    :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
+    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/main/epic_brycecanyon/DIS/NC" }, # FORCE brycecanyon only
+    :energySubDir    => Proc.new { "#{options.energy}" },
+    :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
+  },
   'epic.23.03.0_pythia8' => {
     :comment         => 'Pythia 8, small sample, 10x100, minQ2=1000 only',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
@@ -358,6 +365,7 @@ if [
 
 # pattern: "#{energy}/minQ2=#{minQ2}/"
 elsif [
+  'epic.unstable',
   'epic.23.03.0_pythia8',
   'epic.23.01.0',
   'epic.22.11.2',
@@ -421,6 +429,9 @@ elsif [
       .first(options.limit)
   end
 
+else
+  $stderr.puts "\nERROR: production version '#{options.version}' is missing in RELEASE VERSION DEPENDENT part of #{$0}; add it!"
+  exit 1
 end # END RELEASE VERSION DEPENDENT CODE ##################
 
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Sometimes it's useful to drink directly from the simulation production firehose

Add new production version `epic.unstable`, which we can change as needed to test the bleeding edge of production. Typically only small samples appear here, and `epic.unstable` as a production version is not always guaranteed to work (it depends on when we test and what is on disk).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no