### PR TITLE
fix: remove warning about missing collections in `podio_print_collection_datatypes.C`

### DIFF
--- a/tutorial/podio_print_collection_datatypes.C
+++ b/tutorial/podio_print_collection_datatypes.C
@@ -50,9 +50,11 @@ void podio_print_collection_datatypes(std::string root_file_name) {
             fmt::format("{:<5} {:>45} - {:<45}", coll_id, coll_name, type_name)
             });
       }
-      else
+      /*
+      else // benign issue, see https://github.com/eic/EICrecon/issues/643
         fmt::print(stderr,"WARNING: collection '{}' (id={}) found in collection table, but not in tree '{}'\n",
             coll_name, coll_id, cat_name);
+            */
     }
 
     // print collection types


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Remove unnecessary warning

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no