### PR TITLE
Fill HFS tree in AnalysisEpic, changed HFStree back to storing float …

### DIFF
--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -298,6 +298,8 @@ void AnalysisEpic::Execute()
     // Get the weight for this event's Q2
     auto Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
 
+    if( writeHFSTree && kin->nHFS > 0) HFST->FillTree(Q2weightFactor);
+    
     // fill inclusive histograms, if only `inclusive` is included in output
     // (otherwise they will be filled in track and jet loops)
     if(includeOutputSet["inclusive_only"]) {

--- a/src/HFSTree.cxx
+++ b/src/HFSTree.cxx
@@ -18,9 +18,10 @@ HFSTree::HFSTree(TString treeName_, std::shared_ptr<Kinematics> K_, std::shared_
   T->Branch("vecIonBeamTrue", &(Ktrue->vecIonBeam));
   T->Branch("nHFS", &(K->nHFS), "nHFS/I");
   T->Branch("hfsp4", &(K->hfsp4));
-  //T->Branch("hfspy", &(K->hfspy), "hfspy[nHFS]/F");
-  //T->Branch("hfspz", &(K->hfspz), "hfspz[nHFS]/F");
-  //T->Branch("hfsE", &(K->hfsE), "hfsE[nHFS]/F");
+  T->Branch("hfspx", &(K->hfspx), "hfspx[nHFS]/F");
+  T->Branch("hfspy", &(K->hfspy), "hfspy[nHFS]/F");
+  T->Branch("hfspz", &(K->hfspz), "hfspz[nHFS]/F");
+  T->Branch("hfsE", &(K->hfsE), "hfsE[nHFS]/F");
   T->Branch("hfspid", &(K->hfspid), "hfspid[nHFS]/F");
   T->Branch("weight",    &(weight),       "weight/D");
 };

--- a/src/HFSTree.cxx
+++ b/src/HFSTree.cxx
@@ -18,11 +18,11 @@ HFSTree::HFSTree(TString treeName_, std::shared_ptr<Kinematics> K_, std::shared_
   T->Branch("vecIonBeamTrue", &(Ktrue->vecIonBeam));
   T->Branch("nHFS", &(K->nHFS), "nHFS/I");
   T->Branch("hfsp4", &(K->hfsp4));
-  T->Branch("hfspx", &(K->hfspx), "hfspx[nHFS]/F");
-  T->Branch("hfspy", &(K->hfspy), "hfspy[nHFS]/F");
-  T->Branch("hfspz", &(K->hfspz), "hfspz[nHFS]/F");
-  T->Branch("hfsE", &(K->hfsE), "hfsE[nHFS]/F");
-  T->Branch("hfspid", &(K->hfspid), "hfspid[nHFS]/F");
+  T->Branch("hfspx", &(K->hfspx), "hfspx[nHFS]/D");
+  T->Branch("hfspy", &(K->hfspy), "hfspy[nHFS]/D");
+  T->Branch("hfspz", &(K->hfspz), "hfspz[nHFS]/D");
+  T->Branch("hfsE", &(K->hfsE), "hfsE[nHFS]/D");
+  T->Branch("hfspid", &(K->hfspid), "hfspid[nHFS]/D");
   T->Branch("weight",    &(weight),       "weight/D");
 };
 


### PR DESCRIPTION
…format HFS px/py/pz/E in addition to TLorentzVector

### Briefly, what does this PR introduce?
Added HFStree filling line to AnalysisEpic (should be in each Analysis*.cxx files), default HFSTree to store float values of HFS momentum, energy.  

### What kind of change does this PR introduce?
- [] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [X] Other:

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.
### Does this PR change default behavior?
No.