### PR TITLE
feat: support production 23.05.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 5
-  pbeam_en: 41
+  ebeam_en: 18
+  pbeam_en: 275
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --version epic.23.05.1 --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.23.05.1 --limit 4  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.23.05.1 --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.23.05.1 --limit 4  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --version epic.22.11.3 --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --limit 4  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --limit 4  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 18
-  pbeam_en: 275
+  ebeam_en: 5
+  pbeam_en: 41
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --limit 4  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --limit 4  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --version epic.23.05.1 --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --version epic.23.05.1 --limit 4  --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --version epic.23.05.1 --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --version epic.23.05.1 --limit 4  --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -53,6 +53,13 @@ prodSettings = {
     :energySubDir    => Proc.new { "#{options.energy}" },
     :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
   },
+  'epic.23.05.1' => {
+    :comment         => 'Pythia 8',
+    :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
+    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
+    :energySubDir    => Proc.new { "#{options.energy}" },
+    :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
+  },
   'epic.23.03.0_pythia8' => {
     :comment         => 'Pythia 8, small sample, 10x100, minQ2=1000 only',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
@@ -366,6 +373,7 @@ if [
 # pattern: "#{energy}/minQ2=#{minQ2}/"
 elsif [
   'epic.unstable',
+  'epic.23.05.1',
   'epic.23.03.0_pythia8',
   'epic.23.01.0',
   'epic.22.11.2',

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -55,9 +55,9 @@ void AnalysisEpic::Execute()
   TTreeReaderArray<Float_t> recparts_CHI2PID(tr,  "ReconstructedChargedParticles.goodnessOfPID");
   
   // RecoAssociations
-  TTreeReaderArray<UInt_t> assoc_simID(tr, "ReconstructedChargedParticlesAssociations.simID");
-  TTreeReaderArray<UInt_t> assoc_recID(tr, "ReconstructedChargedParticlesAssociations.recID");
-  TTreeReaderArray<Float_t> assoc_weight(tr, "ReconstructedChargedParticlesAssociations.weight");
+  TTreeReaderArray<UInt_t> assoc_simID(tr, "ReconstructedChargedParticleAssociations.simID");
+  TTreeReaderArray<UInt_t> assoc_recID(tr, "ReconstructedChargedParticleAssociations.recID");
+  TTreeReaderArray<Float_t> assoc_weight(tr, "ReconstructedChargedParticleAssociations.weight");
 
   // calculate Q2 weights
   CalculateEventQ2Weights();

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -23,6 +23,7 @@ void AnalysisEpic::Execute()
     }
   }
   chain->CanDeleteRefs();
+  auto listOfBranches = chain->GetListOfBranches();
 
   TTreeReader tr(chain.get());
 
@@ -55,9 +56,12 @@ void AnalysisEpic::Execute()
   TTreeReaderArray<Float_t> recparts_CHI2PID(tr,  "ReconstructedChargedParticles.goodnessOfPID");
   
   // RecoAssociations
-  TTreeReaderArray<UInt_t> assoc_simID(tr, "ReconstructedChargedParticleAssociations.simID");
-  TTreeReaderArray<UInt_t> assoc_recID(tr, "ReconstructedChargedParticleAssociations.recID");
-  TTreeReaderArray<Float_t> assoc_weight(tr, "ReconstructedChargedParticleAssociations.weight");
+  std::string assoc_branch_name = "ReconstructedChargedParticleAssociations";
+  if(listOfBranches->FindObject(assoc_branch_name.c_str()) == nullptr)
+    assoc_branch_name = "ReconstructedChargedParticlesAssociations"; // productions before 23.5
+  TTreeReaderArray<UInt_t> assoc_simID(tr, (assoc_branch_name+".simID").c_str());
+  TTreeReaderArray<UInt_t> assoc_recID(tr, (assoc_branch_name+".recID").c_str());
+  TTreeReaderArray<Float_t> assoc_weight(tr, (assoc_branch_name+".weight").c_str());
 
   // calculate Q2 weights
   CalculateEventQ2Weights();


### PR DESCRIPTION
Support production 23.05.01. This production also has a TTree branch name change:
```
ReconstructedChargedParticlesAssociations -> ReconstructedChargedParticleAssociations
```
To maintain backward compatibility with previous productions, `AnalysisEpic` now includes a check to determine which branch name to use.