### PR TITLE
Added matched true track kinematics to reconstructed HFS particles to HFSTree

### DIFF
--- a/macro/analysis_makeHFStree.C
+++ b/macro/analysis_makeHFStree.C
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (C) 2023 Connor Pecar
+
+R__LOAD_LIBRARY(EpicAnalysis)
+
+// Produce HFSTree: tree containing all information for kinematic reconstruction
+// studies. Includes:
+//    -true beam and scattered electron information
+//    -reco. scattered electron
+//    -std::vector of momentum, energy, and PID for each hadronic final state (HFS) particle
+//    -std::vector of momentum, energy, and PID for select final state
+//     tracks for SIDIS kinematics (e.g. here pipTrack)
+// Does not place any cuts besides requiring a reconstructed scattered electron
+// and at least 1 reconstructed HFS particle
+void analysis_makeHFStree(
+    TString configFile="datarec/in.config", /* delphes tree(s) */
+    TString outfilePrefix="resolutions" /* output filename prefix*/
+) {
+
+  //outfilePrefix+="_DA";
+  // setup analysis ========================================
+  AnalysisEpic *A = new AnalysisEpic(
+      configFile,
+      outfilePrefix
+      );
+  
+  //A->maxEvents = 1000000; // use this to limit the number of events
+  A->SetReconMethod("ele"); // set reconstruction method
+
+  A->writeHFSTree = true; // write HFSTree (for one bin)
+  A->AddFinalState("pipTrack"); // pion final state
+  //A->AddFinalState("KpTrack"); // kaon final state
+
+
+  // define cuts ====================================
+  A->AddBinScheme("w");  A->BinScheme("w")->BuildBin("Min",3.0); // W > 3 GeV
+  A->AddBinScheme("xF"); A->BinScheme("xF")->BuildBin("Min",0.0); // xF > 0
+  A->AddBinScheme("ptLab");  A->BinScheme("ptLab")->BuildBin("Min",0.1); // pT_lab > 0.1 GeV (tracking limit)
+
+
+  // set binning scheme ====================================
+  // z ranges
+  A->AddBinScheme("z");
+  A->BinScheme("z")->BuildBin("Min",0.2); // needed?
+
+  // y minima
+  A->AddBinScheme("y");
+  A->BinScheme("y")->BuildBin("Full"); // a bin with no y-cut
+
+  // perform the analysis ==================================
+  A->Execute();
+
+};

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -174,6 +174,9 @@ void AnalysisAthena::Execute()
           if(part.mcID == imc.mcID) {
             recopart.push_back(part);
             kin->AddToHFS(part.vecPart);
+	    if( writeHFSTree ){
+	      kin->AddToHFSTree(part.vecPart, part.pid);
+	    }	    
             break;
           }
         }
@@ -240,11 +243,20 @@ void AnalysisAthena::Execute()
       kin->vecHadron = part.vecPart;
       kin->CalculateHadronKinematics();
 
+      // add selected single hadron FS to HFS tree
+      if( writeHFSTree ){
+        kin->AddTrackToHFSTree(part.vecPart, part.pid);
+      }
+
       // find the matching truth hadron using mcID, and calculate its kinematics
       if(mcid_ > 0) {
         for(auto imc : mcpart) {
           if(mcid_ == imc.mcID) {
             kinTrue->vecHadron = imc.vecPart;
+	    // add tracks of interest for kinematic studies to HFSTree
+            if( writeHFSTree ){
+              kinTrue->AddTrackToHFSTree(imc.vecPart, imc.pid);
+            }
             break;
           }
         }
@@ -288,7 +300,10 @@ void AnalysisAthena::Execute()
       }
 
     }//hadron loop
-
+    
+    // fill HFSTree for each event
+    if( writeHFSTree && kin->nHFS > 0) HFST->FillTree(Q2weightFactor);
+    
   } while(tr.Next()); // tree reader loop
   cout << "end event loop" << endl;
   // event loop end =========================================================

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -200,6 +200,7 @@ void AnalysisDelphes::Execute() {
           trk->Phi,
           trk->Mass /* TODO: do we use track mass here ?? */
           );
+
       GenParticle* trkPart = (GenParticle*)trk->Particle.GetObject();
       kinTrue->hadPID = pid;
       kinTrue->vecHadron.SetPtEtaPhiM(
@@ -212,6 +213,11 @@ void AnalysisDelphes::Execute() {
       kin->CalculateHadronKinematics();
       kinTrue->CalculateHadronKinematics();
 
+      if( writeHFSTree ){
+	kin->AddTrackToHFSTree(kin->vecHadron,kin->hadPID);
+	kinTrue->AddTrackToHFSTree(kinTrue->vecHadron,kinTrue->hadPID);
+      }
+      
       // asymmetry injection
       //kin->InjectFakeAsymmetry(); // sets tSpin, based on reconstructed kinematics
       //kinTrue->InjectFakeAsymmetry(); // sets tSpin, based on generated kinematics
@@ -235,7 +241,7 @@ void AnalysisDelphes::Execute() {
 
     }; // end track loop
 
-
+    if( writeHFSTree ) HFST->FillTree(Q2weightFactor);
     // jet loop - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(includeOutputSet["jets"]) {
 

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -196,7 +196,6 @@ void AnalysisEcce::Execute()
 	  // add to hadronic final state sums
 	  kinTrue->AddToHFS(part.vecPart);
 
-
 	  // identify scattered electron by max momentum
 	  if(pid_ == 11) {
 	    if(pt_ > maxPt) {
@@ -309,6 +308,9 @@ void AnalysisEcce::Execute()
 	  //  cout  << "\t\t\t add  to hadfs  \n" ;
 	  recopart.push_back(part);
 	  kin->AddToHFS(part.vecPart);
+	  if( writeHFSTree ){
+	    kin->AddToHFSTree(part.vecPart, part.pid);
+	  }
 	  kin->hfspid[kin->nHFS - 1] = pid_;
 	}
       }
@@ -455,11 +457,20 @@ void AnalysisEcce::Execute()
       kin->vecHadron = part.vecPart;
       kin->CalculateHadronKinematics();
 
+      // add selected single hadron FS to HFS tree
+      if( writeHFSTree ){
+        kin->AddTrackToHFSTree(part.vecPart, part.pid);
+      }
+
       // find the matching truth hadron using mcID, and calculate its kinematics
       if(mcid_ > 0) {
         for(auto imc : mcpart) {
           if(mcid_ == imc.mcID) {
             kinTrue->vecHadron = imc.vecPart;
+	    // add tracks of interest for kinematic studies to HFSTree
+            if( writeHFSTree ){
+              kinTrue->AddTrackToHFSTree(imc.vecPart, imc.pid);
+            }
             break;
           }
         }
@@ -503,8 +514,8 @@ void AnalysisEcce::Execute()
       }
 
     }//hadron loop
-
-
+    
+    if( writeHFSTree && kin->nHFS > 0) HFST->FillTree(Q2weightFactor);
     
   } while(tr.Next()); // tree reader loop
   cout << "end event loop" << endl;

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -311,7 +311,6 @@ void AnalysisEcce::Execute()
 	  if( writeHFSTree ){
 	    kin->AddToHFSTree(part.vecPart, part.pid);
 	  }
-	  kin->hfspid[kin->nHFS - 1] = pid_;
 	}
       }
 

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -268,6 +268,8 @@ void AnalysisEpic::Execute()
 	}
 	// Add the final state particle to the HFS
 	kin->AddToHFS(recpart_.vecPart);
+
+	// Add reconstructed particle and true info to HFSTree
 	if( writeHFSTree ){
 	  int pid = recpart_.pid;
 	  int truepid;

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -283,10 +283,10 @@ void AnalysisEpic::Execute()
 		break;
 	      }
 	    }
+	    kin->AddToHFSTree(recpart_.vecPart, pid,
+			      truep4, truepid
+			      );	    
 	  }	  
-	  kin->AddToHFSTree(recpart_.vecPart, pid,
-			    truep4, truepid
-			    );
 	}
       }
       irec++; // Increment to next particle

--- a/src/AnalysisEpic.cxx
+++ b/src/AnalysisEpic.cxx
@@ -268,6 +268,24 @@ void AnalysisEpic::Execute()
 	}
 	// Add the final state particle to the HFS
 	kin->AddToHFS(recpart_.vecPart);
+	if( writeHFSTree ){
+	  int pid = recpart_.pid;
+	  int truepid;
+	  int mcid_ = recpart_.mcID;
+	  TLorentzVector truep4;
+	  if(mcid_ >= 0) {
+	    for(auto imc : mcpart) {
+	      if(mcid_ == imc.mcID) {
+		truep4 = imc.vecPart;
+		truepid = imc.pid;
+		break;
+	      }
+	    }
+	  }	  
+	  kin->AddToHFSTree(recpart_.vecPart, pid,
+			    truep4, truepid
+			    );
+	}
       }
       irec++; // Increment to next particle
     }

--- a/src/HFSTree.cxx
+++ b/src/HFSTree.cxx
@@ -24,11 +24,17 @@ HFSTree::HFSTree(TString treeName_, std::shared_ptr<Kinematics> K_, std::shared_
   T->Branch("hfsE", &(K->hfsE));
   T->Branch("hfspid", &(K->hfspid));
 
-  T->Branch("hfspxTrue", &(K->hfspxTrue));
-  T->Branch("hfspyTrue", &(K->hfspyTrue));
-  T->Branch("hfspzTrue", &(K->hfspzTrue));
-  T->Branch("hfsETrue", &(K->hfsETrue));
-  T->Branch("hfspidTrue", &(K->hfspidTrue));
+  T->Branch("selectedHadPx", &(K->selectedHadPx));
+  T->Branch("selectedHadPy", &(K->selectedHadPy));
+  T->Branch("selectedHadPz", &(K->selectedHadPz));
+  T->Branch("selectedHadE", &(K->selectedHadE));
+  T->Branch("selectedHadPID", &(K->selectedHadPID));
+
+  T->Branch("selectedHadPxTrue", &(Ktrue->selectedHadPx));
+  T->Branch("selectedHadPyTrue", &(Ktrue->selectedHadPy));
+  T->Branch("selectedHadPzTrue", &(Ktrue->selectedHadPz));
+  T->Branch("selectedHadETrue", &(Ktrue->selectedHadE));
+  T->Branch("selectedHadPIDTrue", &(Ktrue->selectedHadPID));
   
   T->Branch("weight",    &(weight),       "weight/D");
 };

--- a/src/HFSTree.cxx
+++ b/src/HFSTree.cxx
@@ -17,12 +17,19 @@ HFSTree::HFSTree(TString treeName_, std::shared_ptr<Kinematics> K_, std::shared_
   T->Branch("vecEleBeamTrue", &(Ktrue->vecEleBeam));
   T->Branch("vecIonBeamTrue", &(Ktrue->vecIonBeam));
   T->Branch("nHFS", &(K->nHFS), "nHFS/I");
-  T->Branch("hfsp4", &(K->hfsp4));
-  T->Branch("hfspx", &(K->hfspx), "hfspx[nHFS]/D");
-  T->Branch("hfspy", &(K->hfspy), "hfspy[nHFS]/D");
-  T->Branch("hfspz", &(K->hfspz), "hfspz[nHFS]/D");
-  T->Branch("hfsE", &(K->hfsE), "hfsE[nHFS]/D");
-  T->Branch("hfspid", &(K->hfspid), "hfspid[nHFS]/D");
+
+  T->Branch("hfspx", &(K->hfspx));
+  T->Branch("hfspy", &(K->hfspy));
+  T->Branch("hfspz", &(K->hfspz));
+  T->Branch("hfsE", &(K->hfsE));
+  T->Branch("hfspid", &(K->hfspid));
+
+  T->Branch("hfspxTrue", &(K->hfspxTrue));
+  T->Branch("hfspyTrue", &(K->hfspyTrue));
+  T->Branch("hfspzTrue", &(K->hfspzTrue));
+  T->Branch("hfsETrue", &(K->hfsETrue));
+  T->Branch("hfspidTrue", &(K->hfspidTrue));
+  
   T->Branch("weight",    &(weight),       "weight/D");
 };
 

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -540,6 +540,8 @@ void Kinematics::AddToHFS(TLorentzVector p4_) {
   countHadrons++;
 };
 
+// add reconstructed and true information from a
+// reconstructed track to HFSTree
 void Kinematics::AddToHFSTree(TLorentzVector p4, int pid,
 			      TLorentzVector p4true, int pidtrue
 			      ) {

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -34,7 +34,7 @@ Kinematics::Kinematics(
   // set method for determining `vecQ` 4-momentum components for certain recon methods (JB,DA,(e)Sigma)
   qComponentsMethod = qQuadratic; // qQuadratic, qHadronic, qElectronic
   /////////////////////////////////////////////////////////////
-
+  
   // set beam 4-momenta
   // - electron beam points toward negative z
   // - ion beam points toward positive z, negative x
@@ -532,13 +532,6 @@ void Kinematics::ValidateHeadOnFrame() {
 // add a 4-momentum to the hadronic final state
 void Kinematics::AddToHFS(TLorentzVector p4_) {
   TLorentzVector p4 = p4_;
-  hfspx[nHFS] = p4.Px();
-  hfspy[nHFS] = p4.Py();
-  hfspz[nHFS] = p4.Pz();
-  hfsE[nHFS] = p4.E();
-  new(ar[nHFS]) TLorentzVector(p4);
-  nHFS++;
-  
   if(mainFrame==fHeadOn) this->TransformToHeadOnFrame(p4,p4);
   sigmah += (p4.E() - p4.Pz());
   Pxh += p4.Px();
@@ -546,6 +539,26 @@ void Kinematics::AddToHFS(TLorentzVector p4_) {
   hadronSumVec += p4;
   countHadrons++;
 };
+
+void Kinematics::AddToHFSTree(TLorentzVector p4, int pid,
+			      TLorentzVector p4true, int pidtrue
+			      ) {
+  hfspx[nHFS] = p4.Px();
+  hfspy[nHFS] = p4.Py();
+  hfspz[nHFS] = p4.Pz();
+  hfsE[nHFS] = p4.E();
+  new(ar[nHFS]) TLorentzVector(p4);  
+  hfspid[nHFS] = pid;
+
+  hfspxTrue[nHFS] = p4true.Px();
+  hfspyTrue[nHFS] = p4true.Py();
+  hfspzTrue[nHFS] = p4true.Pz();
+  hfsETrue[nHFS] = p4true.E();
+  hfspidTrue[nHFS] = pidtrue;
+  
+  nHFS++;
+};
+
 
 void Kinematics::AddPion(TLorentzVector p4_){
   TLorentzVector p4 = p4_;

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -212,9 +212,7 @@ void Kinematics::GetQWNu_ML(){
       if(abs(hfspid[i])==22) pidadj = 0.2*pidsgn;
       if(abs(hfspid[i])==321) pidadj = 0.6*pidsgn;
       if(abs(hfspid[i])==2212) pidadj = 0.8*pidsgn;
-      if(abs(hfspid[i])==11) pidadj = 1.0*pidsgn;
-      partHold.push_back(hfseta[i]);
-      partHold.push_back(hfsphi[i]);
+      if(abs(hfspid[i])==11) pidadj = 1.0*pidsgn;      
       partHold.push_back(hfspx[i]);
       partHold.push_back(hfspy[i]);
       partHold.push_back(hfspz[i]);
@@ -545,28 +543,19 @@ void Kinematics::AddToHFS(TLorentzVector p4_) {
 void Kinematics::AddToHFSTree(TLorentzVector p4, int pid,
 			      TLorentzVector p4true, int pidtrue
 			      ) {
-  hfspx[nHFS] = p4.Px();
-  hfspy[nHFS] = p4.Py();
-  hfspz[nHFS] = p4.Pz();
-  hfsE[nHFS] = p4.E();
-  new(ar[nHFS]) TLorentzVector(p4);  
-  hfspid[nHFS] = pid;
+  hfspx.push_back(p4.Px());
+  hfspy.push_back(p4.Py());
+  hfspz.push_back(p4.Pz());
+  hfsE.push_back(p4.E());
+  hfspid.push_back(pid);
 
-  hfspxTrue[nHFS] = p4true.Px();
-  hfspyTrue[nHFS] = p4true.Py();
-  hfspzTrue[nHFS] = p4true.Pz();
-  hfsETrue[nHFS] = p4true.E();
-  hfspidTrue[nHFS] = pidtrue;
+  hfspxTrue.push_back(p4true.Px());
+  hfspyTrue.push_back(p4true.Py());
+  hfspzTrue.push_back(p4true.Pz());
+  hfsETrue.push_back(p4true.E());
+  hfspidTrue.push_back(pidtrue);
   
   nHFS++;
-};
-
-
-void Kinematics::AddPion(TLorentzVector p4_){
-  TLorentzVector p4 = p4_;
-  if(mainFrame==fHeadOn) this->TransformToHeadOnFrame(p4,p4);
-  new(arpi[nPi]) TLorentzVector(p4);
-  nPi++;
 };
 
 // subtract electron from hadronic final state variables
@@ -587,9 +576,7 @@ void Kinematics::SubtractElectronFromHFS() {
         hadronSumVec -= HvecElectron;
         break;
     }
-    countHadrons--;
-    ar.Remove( &vecElectron );
-    nHFS--;
+    countHadrons--;    
   } else {
     cerr << "ERROR: electron energy is NaN" << endl;
     // TODO: kill event
@@ -604,8 +591,18 @@ void Kinematics::ResetHFS() {
   countHadrons = 0;
   nHFS = 0;
   nPi = 0;
-  ar.Clear();
-  arpi.Clear();
+  hfspx.clear();
+  hfspy.clear();
+  hfspz.clear();
+  hfsE.clear();
+  hfspid.clear();
+  
+  hfspxTrue.clear();
+  hfspyTrue.clear();
+  hfspzTrue.clear();
+  hfsETrue.clear();
+  hfspidTrue.clear();
+    
 };
 
 

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -654,6 +654,7 @@ void Kinematics::GetHFS(
         }
 
         this->AddToHFS(trackp4);
+	this->AddToHFSTree(trackp4,pid);
       }
     }    
   }
@@ -661,9 +662,18 @@ void Kinematics::GetHFS(
   // eflow high |eta| track loop
   while(Track *eflowTrack = (Track*)itEFlowTrack() ){
     TLorentzVector eflowTrackp4 = eflowTrack->P4();
+    int pid = GetTrackPID( // get smeared PID                                                                     
+            eflowTrack,
+            itpfRICHTrack,
+            itDIRCepidTrack, itDIRChpidTrack,
+            itBTOFepidTrack, itBTOFhpidTrack,
+            itdualRICHagTrack, itdualRICHcfTrack
+            );
+
     if(!isnan(eflowTrackp4.E())){
       if(std::abs(eflowTrack->Eta) >= 4.0){
         this->AddToHFS(eflowTrackp4);
+	this->AddToHFSTree(eflowTrackp4, pid);
       }
     }
   }
@@ -674,6 +684,7 @@ void Kinematics::GetHFS(
     if(!isnan(towerPhotonp4.E())){
       if( std::abs(towerPhoton->Eta) < 4.0  ){
         this->AddToHFS(towerPhotonp4);
+	this->AddToHFSTree(towerPhotonp4,22);
       }
     }
   }
@@ -684,6 +695,7 @@ void Kinematics::GetHFS(
     if(!isnan(towerNeutralHadronp4.E())){
       if( std::abs(towerNeutralHadron->Eta) < 4.0 ){
         this->AddToHFS(towerNeutralHadronp4);
+	this->AddToHFSTree(towerNeutralHadronp4,-1);
       }
     }
   }

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -538,24 +538,26 @@ void Kinematics::AddToHFS(TLorentzVector p4_) {
   countHadrons++;
 };
 
-// add reconstructed and true information from a
-// reconstructed track to HFSTree
-void Kinematics::AddToHFSTree(TLorentzVector p4, int pid,
-			      TLorentzVector p4true, int pidtrue
-			      ) {
+// add  information from a reconstructed particle to HFSTree
+// branches containing full HFS
+void Kinematics::AddToHFSTree(TLorentzVector p4, int pid) {
   hfspx.push_back(p4.Px());
   hfspy.push_back(p4.Py());
   hfspz.push_back(p4.Pz());
   hfsE.push_back(p4.E());
   hfspid.push_back(pid);
 
-  hfspxTrue.push_back(p4true.Px());
-  hfspyTrue.push_back(p4true.Py());
-  hfspzTrue.push_back(p4true.Pz());
-  hfsETrue.push_back(p4true.E());
-  hfspidTrue.push_back(pidtrue);
-  
   nHFS++;
+};
+
+// add a specific track and its matched true four momentum
+// to HFSTree for final kinematic calculations (not full HFS)
+void Kinematics::AddTrackToHFSTree(TLorentzVector p4, int pid) {
+  selectedHadPx.push_back(p4.Px());
+  selectedHadPy.push_back(p4.Py());
+  selectedHadPz.push_back(p4.Pz());
+  selectedHadE.push_back(p4.E());
+  selectedHadPID.push_back(pid);  
 };
 
 // subtract electron from hadronic final state variables
@@ -590,19 +592,18 @@ void Kinematics::ResetHFS() {
   hadronSumVec.SetPxPyPzE(0,0,0,0);
   countHadrons = 0;
   nHFS = 0;
-  nPi = 0;
+  
   hfspx.clear();
   hfspy.clear();
   hfspz.clear();
   hfsE.clear();
   hfspid.clear();
   
-  hfspxTrue.clear();
-  hfspyTrue.clear();
-  hfspzTrue.clear();
-  hfsETrue.clear();
-  hfspidTrue.clear();
-    
+  selectedHadPx.clear();
+  selectedHadPy.clear();
+  selectedHadPz.clear();
+  selectedHadE.clear();
+  selectedHadPID.clear();    
 };
 
 

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -55,9 +55,8 @@ class Kinematics
 
     // hadronic final state (HFS)
     void AddToHFS(TLorentzVector p4_);
-    void AddToHFSTree(TLorentzVector p4, int pid,
-		      TLorentzVector p4true, int pidtrue);
-    void AddPion(TLorentzVector p4_);
+    void AddToHFSTree(TLorentzVector p4, int pid);   	      
+    void AddTrackToHFSTree(TLorentzVector p4, int pid);			   
     void SubtractElectronFromHFS();
     void ResetHFS();
 
@@ -125,23 +124,22 @@ class Kinematics
     TLorentzVector vecElectron, vecW, vecQ;
     TLorentzVector vecHadron;
 
-  // HFS tree objects
-    Int_t nHFS;
-    Int_t nPi;
+    // HFS tree objects
+    Int_t nHFS;    
     std::vector<double> hfspx;
     std::vector<double> hfspy;
     std::vector<double> hfspz;
     std::vector<double> hfsE;
     std::vector<int> hfspid;
 
-  // HFS tree true associated tracks
-  // (NOT full true HFS, just those associated with reco HFS)
-    std::vector<double> hfspxTrue;
-    std::vector<double> hfspyTrue;
-    std::vector<double> hfspzTrue;
-    std::vector<double> hfsETrue;
-    std::vector<int> hfspidTrue;
-  
+    // HFS tree select FS tracks and matched true p4
+    // (NOT full true HFS)
+    std::vector<double> selectedHadPx;
+    std::vector<double> selectedHadPy;
+    std::vector<double> selectedHadPz;
+    std::vector<double> selectedHadE;
+    std::vector<int> selectedHadPID;
+
     // TMVA for ML sidis reconstruction
     std::vector<std::vector<float>> hfsinfo;
     std::vector<float> globalinfo;

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
+ // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023 Christopher Dilks, Connor Pecar, Duane Byer, Sanghwa Park, Brian Page
 
 /* NOTE:
@@ -55,6 +55,8 @@ class Kinematics
 
     // hadronic final state (HFS)
     void AddToHFS(TLorentzVector p4_);
+    void AddToHFSTree(TLorentzVector p4, int pid,
+		      TLorentzVector p4true, int pidtrue);
     void AddPion(TLorentzVector p4_);
     void SubtractElectronFromHFS();
     void ResetHFS();
@@ -133,6 +135,16 @@ class Kinematics
     Double_t hfseta[100];
     Double_t hfsphi[100];
     Int_t hfspid[100];
+  // HFS tree true associated tracks
+  // (NOT full true HFS, just those associated with reco HFS)
+    Double_t hfspxTrue[100];
+    Double_t hfspyTrue[100];
+    Double_t hfspzTrue[100];
+    Double_t hfsETrue[100];
+    Double_t hfsetaTrue[100];
+    Double_t hfsphiTrue[100];
+    Int_t hfspidTrue[100];
+  
     TClonesArray *hfsp4 = new TClonesArray("TLorentzVector");
     TClonesArray &ar    = *hfsp4;
     TClonesArray *pip4  = new TClonesArray("TLorentzVector");

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -1,4 +1,4 @@
- // SPDX-License-Identifier: LGPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (C) 2023 Christopher Dilks, Connor Pecar, Duane Byer, Sanghwa Park, Brian Page
 
 /* NOTE:

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -128,27 +128,20 @@ class Kinematics
   // HFS tree objects
     Int_t nHFS;
     Int_t nPi;
-    Double_t hfspx[100];
-    Double_t hfspy[100];
-    Double_t hfspz[100];
-    Double_t hfsE[100];
-    Double_t hfseta[100];
-    Double_t hfsphi[100];
-    Int_t hfspid[100];
+    std::vector<double> hfspx;
+    std::vector<double> hfspy;
+    std::vector<double> hfspz;
+    std::vector<double> hfsE;
+    std::vector<int> hfspid;
+
   // HFS tree true associated tracks
   // (NOT full true HFS, just those associated with reco HFS)
-    Double_t hfspxTrue[100];
-    Double_t hfspyTrue[100];
-    Double_t hfspzTrue[100];
-    Double_t hfsETrue[100];
-    Double_t hfsetaTrue[100];
-    Double_t hfsphiTrue[100];
-    Int_t hfspidTrue[100];
+    std::vector<double> hfspxTrue;
+    std::vector<double> hfspyTrue;
+    std::vector<double> hfspzTrue;
+    std::vector<double> hfsETrue;
+    std::vector<int> hfspidTrue;
   
-    TClonesArray *hfsp4 = new TClonesArray("TLorentzVector");
-    TClonesArray &ar    = *hfsp4;
-    TClonesArray *pip4  = new TClonesArray("TLorentzVector");
-    TClonesArray &arpi  = *pip4;
     // TMVA for ML sidis reconstruction
     std::vector<std::vector<float>> hfsinfo;
     std::vector<float> globalinfo;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
For ease of SIDIS kinematic reconstruction studies, added the matched true track momentum to the output of HFS tree. This isn't the full true hadronic final state, just the true momenta of reconstructed tracks.

Also added a different function to fill HFSTree variables. Was previously included as part of Kinematics::AddToHFS
### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.
### Does this PR change default behavior?
No.