### PR TITLE
feat: update default production version to 23.05.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --version epic.22.11.3 --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --version epic.22.11.3 --limit 4  --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --version epic.22.11.3 --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --version epic.22.11.3 --limit 4  --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --limit 20 --detector arches      } # max limit=150
+          - { id: epic_brycecanyon,        options: --limit 20 --detector brycecanyon } # max limit=35
+          - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor } # max limit=150
+          - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor } # max limit=35
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --limit 20 --detector arches      } # max limit=150
-          - { id: epic_brycecanyon,        options: --limit 20 --detector brycecanyon } # max limit=35
-          - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor } # max limit=150
-          - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor } # max limit=35
+          - { id: epic_arches,             options: --limit 20 --detector arches      }
+          - { id: epic_brycecanyon,        options: --limit 20 --detector brycecanyon }
+          - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor }
+          - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor }
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 
 # default CLI options
 options = OpenStruct.new
-options.version    = 'epic.22.11.3'
+options.version    = 'epic.23.05.2'
 options.energy     = '18x275'
 options.locDir     = ''
 options.mode       = 's'
@@ -54,7 +54,7 @@ prodSettings = {
     :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
   },
   'epic.23.05.2' => {
-    :comment         => 'Pythia 8',
+    :comment         => 'Pythia 8: high-stats May 2023 production',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
     :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
     :energySubDir    => Proc.new { "#{options.energy}" },
@@ -89,7 +89,7 @@ prodSettings = {
     :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
   },
   'epic.22.11.3' => {
-    :comment         => 'Pythia 6, with & without radiative corrections',
+    :comment         => 'Pythia 6: high-stats November 2022 production, with & without radiative corrections',
     :crossSectionID  => Proc.new { |minQ2,maxQ2,radDir| "pythia6:ep_#{radDir}.#{options.energy}_q2_#{minQ2}_#{maxQ2}" },
     :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/SIDIS/pythia6" },
     :energySubDir    => Proc.new { "ep_#{options.energy}" },
@@ -102,7 +102,7 @@ prodSettings = {
     },
   },
   'epic.22.11.2' => {
-    :comment         => 'Pythia 8',
+    :comment         => 'Pythia 8: high-stats November 2022 production',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
     :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
     :energySubDir    => Proc.new { "#{options.energy}" },


### PR DESCRIPTION
### Briefly, what does this PR introduce?
23.05.02 is the large-statistics May 2023 production. Update to this default in `s3tool.rb`. Additionally update the default in CI (by simply removing the `--version` specification).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No, but this is a new default production.