### PR TITLE
feat: support production 23.06.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,7 +552,7 @@ jobs:
   collect:
     needs: 
       - postprocess
-      # - comparison
+      - comparison
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -560,10 +560,10 @@ jobs:
         with:
           name: postprocess
           path: results
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: comparison
-      #     path: results
+      - uses: actions/download-artifact@v3
+        with:
+          name: comparison
+          path: results
       - name: tree_artifacts
         run: tree results
       - name: cull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - { id: epic_latest,   options: --version ${{env.prod_latest}}    --limit 20 --detector brycecanyon --no-radcor }
-          - { id: epic_previous, options: --version ${{env.prod_previous}}  --limit 20 --detector brycecanyon --no-radcor }
-          - { id: ecce,          options: --version ecce.22.1               --limit 40 }
-          - { id: athena,        options: --version athena.deathvalley-v1.0 --limit 20 }
+          - { id: epic_latest,   options: "--version ${{env.prod_latest}}    --limit 20 --detector brycecanyon --no-radcor" }
+          - { id: epic_previous, options: "--version ${{env.prod_previous}}  --limit 20 --detector brycecanyon --no-radcor" }
+          - { id: ecce,          options: "--version ecce.22.1               --limit 40" }
+          - { id: athena,        options: "--version athena.deathvalley-v1.0 --limit 20" }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         include:
           # ePIC
           # - { id: epic_arches,             options: --limit 20 --detector arches      }
-          - { id: epic_brycecanyon,        options: --limit 20 --detector brycecanyon }
+          - { id: epic_brycecanyon,        options: --limit 100 --detector brycecanyon }
           # - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor }
           # - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor }
           # ECCE / ATHENA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ env:
   pbeam_en: 275
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
+  prod_latest: epic.23.06.1
+  prod_previous: epic.23.05.2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -138,14 +140,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          # ePIC
-          # - { id: epic_arches,             options: --limit 20 --detector arches      }
-          - { id: epic_brycecanyon,        options: --limit 300 --detector brycecanyon }
-          # - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor }
-          # - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor }
-          # ECCE / ATHENA
-          - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
-          - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500
+          - { id: epic_latest,   options: --version ${{env.prod_latest}}    --limit 20 --detector brycecanyon --no-radcor }
+          - { id: epic_previous, options: --version ${{env.prod_previous}}  --limit 20 --detector brycecanyon --no-radcor }
+          - { id: ecce,          options: --version ecce.22.1               --limit 40 }
+          - { id: athena,        options: --version athena.deathvalley-v1.0 --limit 20 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -238,35 +236,23 @@ jobs:
       fail-fast: true
       matrix:
         detector:
-          # - epic_arches
-          - epic_brycecanyon
-          # - epic_arches_radcor
-          # - epic_brycecanyon_radcor
+          - epic_latest
+          - epic_previous
           - athena
           - ecce
         aname: [x_q2, p_eta, yRatio, single_bin]
         recon: [Ele]
         include: # enable other recon methods for `aname==x_q2` only
-        # - { aname: x_q2, recon: Mixed,  detector: epic_arches } # FIXME: not sure how to avoid being repetitive... 
-        # - { aname: x_q2, recon: JB,     detector: epic_arches }
-        # - { aname: x_q2, recon: DA,     detector: epic_arches }
-        # - { aname: x_q2, recon: Sigma,  detector: epic_arches }
-        # - { aname: x_q2, recon: eSigma, detector: epic_arches }
-        - { aname: x_q2, recon: Mixed,  detector: epic_brycecanyon }
-        - { aname: x_q2, recon: JB,     detector: epic_brycecanyon }
-        - { aname: x_q2, recon: DA,     detector: epic_brycecanyon }
-        - { aname: x_q2, recon: Sigma,  detector: epic_brycecanyon }
-        - { aname: x_q2, recon: eSigma, detector: epic_brycecanyon }
-        # - { aname: x_q2, recon: Mixed,  detector: epic_arches_radcor }
-        # - { aname: x_q2, recon: JB,     detector: epic_arches_radcor }
-        # - { aname: x_q2, recon: DA,     detector: epic_arches_radcor }
-        # - { aname: x_q2, recon: Sigma,  detector: epic_arches_radcor }
-        # - { aname: x_q2, recon: eSigma, detector: epic_arches_radcor }
-        # - { aname: x_q2, recon: Mixed,  detector: epic_brycecanyon_radcor }
-        # - { aname: x_q2, recon: JB,     detector: epic_brycecanyon_radcor }
-        # - { aname: x_q2, recon: DA,     detector: epic_brycecanyon_radcor }
-        # - { aname: x_q2, recon: Sigma,  detector: epic_brycecanyon_radcor }
-        # - { aname: x_q2, recon: eSigma, detector: epic_brycecanyon_radcor }
+        - { aname: x_q2, recon: Mixed,  detector: epic_latest } # FIXME: not sure how to avoid being repetitive... 
+        - { aname: x_q2, recon: JB,     detector: epic_latest }
+        - { aname: x_q2, recon: DA,     detector: epic_latest }
+        - { aname: x_q2, recon: Sigma,  detector: epic_latest }
+        - { aname: x_q2, recon: eSigma, detector: epic_latest }
+        - { aname: x_q2, recon: Mixed,  detector: epic_previous }
+        - { aname: x_q2, recon: JB,     detector: epic_previous }
+        - { aname: x_q2, recon: DA,     detector: epic_previous }
+        - { aname: x_q2, recon: Sigma,  detector: epic_previous }
+        - { aname: x_q2, recon: eSigma, detector: epic_previous }
         - { aname: x_q2, recon: Mixed,  detector: athena }
         - { aname: x_q2, recon: JB,     detector: athena }
         - { aname: x_q2, recon: DA,     detector: athena }
@@ -359,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        detector: [epic_brycecanyon]
+        detector: [epic_latest]
         aname: [x_q2]
         recon: [Ele]
     steps:
@@ -402,10 +388,8 @@ jobs:
       matrix:
         mode:
           - fastsim
-          # - epic_arches
-          - epic_brycecanyon
-          # - epic_arches_radcor
-          # - epic_brycecanyon_radcor
+          - epic_latest
+          - epic_previous
           - athena
           - ecce
         pname: # list only jobs which will only use one (primary) recon method
@@ -423,48 +407,36 @@ jobs:
           - { pname: q2_weights_test,  aname: single_bin, pmacro: postprocess_q2_weights.C      }
           - { pname: eta_vs_p_forPID,  aname: single_bin, pmacro: postprocess_eta_vs_p_forPID.C }
           # use all reconstruction methods: # FIXME: not sure how to avoid being repetitive... 
-          - { mode: fastsim,                 pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: fastsim,                 pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: fastsim,                 pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: fastsim,                 pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: fastsim,                 pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: fastsim,                 pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: athena,                  pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: athena,                  pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: athena,                  pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: athena,                  pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: athena,                  pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: athena,                  pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: ecce,                    pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: ecce,                    pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: ecce,                    pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: ecce,                    pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: ecce,                    pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: ecce,                    pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: fastsim,       pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: fastsim,       pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: fastsim,       pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: fastsim,       pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: fastsim,       pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: fastsim,       pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_latest,   pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_latest,   pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_latest,   pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_latest,   pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_latest,   pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_latest,   pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_previous, pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_previous, pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_previous, pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_previous, pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_previous, pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: epic_previous, pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: athena,        pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: athena,        pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: athena,        pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: athena,        pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: athena,        pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: athena,        pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: ecce,          pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: ecce,          pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: ecce,          pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: ecce,          pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: ecce,          pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          - { mode: ecce,          pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
@@ -502,79 +474,79 @@ jobs:
 # COMPARATORS ---------------------------------------------------------------------------
 
 # run compare macros matrix for fastsim vs. fullsim
-  # comparison:
-  #   needs:
-  #     - analysis_fastsim
-  #     - analysis_fullsim
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       pname: # list only jobs which will only use one (primary) recon method
-  #         - coverage_p_eta
-  #         - resolution_p_eta
-  #       recon: [Ele] # primary recon method(s)
-  #       include:
-  #         # use only primary recon method
-  #         - { pname: coverage_p_eta,   aname: p_eta, xvar: p, yvar: eta }
-  #         - { pname: resolution_p_eta, aname: p_eta, xvar: p, yvar: eta }
-  #         # use all reconstruction methods:
-  #         ## resolution
-  #         - { pname: resolution_x_q2, recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: resolution_x_q2, recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: resolution_x_q2, recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: resolution_x_q2, recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: resolution_x_q2, recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: resolution_x_q2, recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
-  #         ## coverage
-  #         - { pname: coverage_x_q2,   recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: coverage_x_q2,   recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: coverage_x_q2,   recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: coverage_x_q2,   recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: coverage_x_q2,   recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
-  #         - { pname: coverage_x_q2,   recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: x_build_no_delphes
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: analysis
-  #         path: out
-  #     - uses: cvmfs-contrib/github-action-cvmfs@v3
-  #     - uses: eic/run-cvmfs-osg-eic-shell@main
-  #       with:
-  #         platform-release: "jug_xl:nightly"
-  #         setup: environ.sh
-  #         run: |
-  #           echo "[CI] job matrix params:"
-  #           echo "aname = ${{matrix.aname}}"
-  #           echo "pname = ${{matrix.pname}}"
-  #           echo "recon = ${{matrix.recon}}"
-  #           echo "xvar = ${{matrix.xvar}}"
-  #           echo "yvar = ${{matrix.yvar}}"
-  #           echo "[CI] COMPARATOR MACRO: ePIC"
-  #           macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-  #             'ePIC Arches (no radcor)'      'epic_arches'             \
-  #             'ePIC BryceCanyon (no radcor)' 'epic_brycecanyon'        \
-  #             'ePIC Arches (radcor)'         'epic_arches_radcor'      \
-  #             'ePIC BryceCanyon (radcor)'    'epic_brycecanyon_radcor' \
-  #             'ePIC'
-  #           echo "[CI] COMPARATOR MACRO: LEGACY"
-  #           macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-  #             'Delphes Pythia6 (no radcor)' 'fastsim'     \
-  #             'ePIC Arches (no radcor)'     'epic_arches' \
-  #             'ATHENA'                      'athena'      \
-  #             'ECCE'                        'ecce'        \
-  #             'LEGACY'
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         name: comparison
-  #         retention-days: 30
-  #         path: |
-  #           out/comparison*.images/*.png
-  #           out/comparison*.root
+  comparison:
+    needs:
+      - analysis_fastsim
+      - analysis_fullsim
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pname: # list only jobs which will only use one (primary) recon method
+          - coverage_p_eta
+          - resolution_p_eta
+        recon: [Ele] # primary recon method(s)
+        include:
+          # use only primary recon method
+          - { pname: coverage_p_eta,   aname: p_eta, xvar: p, yvar: eta }
+          - { pname: resolution_p_eta, aname: p_eta, xvar: p, yvar: eta }
+          # use all reconstruction methods:
+          ## resolution
+          - { pname: resolution_x_q2, recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: resolution_x_q2, recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: resolution_x_q2, recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: resolution_x_q2, recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: resolution_x_q2, recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: resolution_x_q2, recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
+          ## coverage
+          - { pname: coverage_x_q2,   recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: coverage_x_q2,   recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: coverage_x_q2,   recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: coverage_x_q2,   recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: coverage_x_q2,   recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
+          - { pname: coverage_x_q2,   recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: x_build_no_delphes
+      - uses: actions/download-artifact@v3
+        with:
+          name: analysis
+          path: out
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: eic/run-cvmfs-osg-eic-shell@main
+        with:
+          platform-release: "jug_xl:nightly"
+          setup: environ.sh
+          run: |
+            echo "[CI] job matrix params:"
+            echo "aname = ${{matrix.aname}}"
+            echo "pname = ${{matrix.pname}}"
+            echo "recon = ${{matrix.recon}}"
+            echo "xvar = ${{matrix.xvar}}"
+            echo "yvar = ${{matrix.yvar}}"
+            echo "[CI] COMPARATOR MACRO: ePIC"
+            macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
+              "${{env.prod_latest}}"   "epic_latest"   \
+              "${{env.prod_previous}}" "epic_previous" \
+              "ecce"                   "ecce"          \
+              "delphes"                "fastsim"       \
+              "epic_productions"
+            # echo "[CI] COMPARATOR MACRO: LEGACY"
+            # macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
+            #   "Delphes Pythia6 (no radcor)" "fastsim"     \
+            #   "ePIC Arches (no radcor)"     "epic_latest" \
+            #   "ATHENA"                      "athena"      \
+            #   "ECCE"                        "ecce"        \
+            #   "LEGACY"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: comparison
+          retention-days: 30
+          path: |
+            out/comparison*.images/*.png
+            out/comparison*.root
 
 # ARTIFACTS ---------------------------------------------------------------------------
 
@@ -616,16 +588,10 @@ jobs:
           tree results
       - name: merge_fastfull
         run: |
-          # macro/ci/merge-fastfull.sh results \
-          #   epic_arches             \
-          #   epic_brycecanyon        \
-          #   epic_arches_radcor      \
-          #   epic_brycecanyon_radcor \
-          #   ecce                    \
-          #   athena
           macro/ci/merge-fastfull.sh results \
-            epic_brycecanyon        \
-            ecce                    \
+            epic_latest   \
+            epic_previous \
+            ecce          \
             athena
           tree results
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - { id: epic_latest,   options: "--version ${{env.prod_latest}}    --limit 20 --detector brycecanyon --no-radcor" }
-          - { id: epic_previous, options: "--version ${{env.prod_previous}}  --limit 20 --detector brycecanyon --no-radcor" }
-          - { id: ecce,          options: "--version ecce.22.1               --limit 40" }
-          - { id: athena,        options: "--version athena.deathvalley-v1.0 --limit 20" }
+          - { id: epic_latest,   options: --version epic_latest             --limit 20 --detector brycecanyon --no-radcor }
+          - { id: epic_previous, options: --version epic_previous           --limit 20 --detector brycecanyon --no-radcor }
+          - { id: ecce,          options: --version ecce.22.1               --limit 40 }
+          - { id: athena,        options: --version athena.deathvalley-v1.0 --limit 20 }
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -162,7 +162,7 @@ jobs:
               --output ${{matrix.id}} \
               --mode   s \
               --config s3files.config \
-              ${{matrix.options}}
+              $(echo ${{matrix.options}} | sed "s;epic_latest;${{env.prod_latest}};g" | sed "s;epic_previous;${{env.prod_previous}};g")
             echo "[CI] cat config file"
             cat s3files.config
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ env:
   pbeam_en: 275
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
-  prod_latest: epic.23.06.1
-  prod_previous: epic.23.05.2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -140,8 +138,8 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - { id: epic_latest,   options: --version epic_latest             --limit 20 --detector brycecanyon --no-radcor }
-          - { id: epic_previous, options: --version epic_previous           --limit 20 --detector brycecanyon --no-radcor }
+          - { id: epic_latest,   options: --version epic.latest             --limit 20 --detector brycecanyon --no-radcor }
+          - { id: epic_previous, options: --version epic.previous           --limit 20 --detector brycecanyon --no-radcor }
           - { id: ecce,          options: --version ecce.22.1               --limit 40 }
           - { id: athena,        options: --version athena.deathvalley-v1.0 --limit 20 }
     steps:
@@ -162,7 +160,7 @@ jobs:
               --output ${{matrix.id}} \
               --mode   s \
               --config s3files.config \
-              $(echo ${{matrix.options}} | sed "s;epic_latest;${{env.prod_latest}};g" | sed "s;epic_previous;${{env.prod_previous}};g")
+              ${{matrix.options}}
             echo "[CI] cat config file"
             cat s3files.config
       - uses: actions/upload-artifact@v3
@@ -528,10 +526,10 @@ jobs:
             echo "yvar = ${{matrix.yvar}}"
             echo "[CI] COMPARATOR MACRO: ePIC"
             macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-              "${{env.prod_latest}}"   "epic_latest"   \
-              "${{env.prod_previous}}" "epic_previous" \
-              "ecce"                   "ecce"          \
-              "delphes"                "fastsim"       \
+              "ePIC Latest"   "epic_latest"   \
+              "ePIC Previous" "epic_previous" \
+              "ECCE"          "ecce"          \
+              "Delphes"       "fastsim"       \
               "epic_productions"
             # echo "[CI] COMPARATOR MACRO: LEGACY"
             # macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         include:
           # ePIC
           # - { id: epic_arches,             options: --limit 20 --detector arches      }
-          - { id: epic_brycecanyon,        options: --limit 100 --detector brycecanyon }
+          - { id: epic_brycecanyon,        options: --limit 300 --detector brycecanyon }
           # - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor }
           # - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor }
           # ECCE / ATHENA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           # ePIC
-          - { id: epic_arches,             options: --limit 20 --detector arches      }
+          # - { id: epic_arches,             options: --limit 20 --detector arches      }
           - { id: epic_brycecanyon,        options: --limit 20 --detector brycecanyon }
-          - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor }
-          - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor }
+          # - { id: epic_arches_radcor,      options: --limit 20 --detector arches      --radcor }
+          # - { id: epic_brycecanyon_radcor, options: --limit 20 --detector brycecanyon --radcor }
           # ECCE / ATHENA
           - { id: ecce,   options: --version ecce.22.1               --limit 40 } # max limit=375
           - { id: athena, options: --version athena.deathvalley-v1.0 --limit 20 } # max limit=500
@@ -238,35 +238,35 @@ jobs:
       fail-fast: true
       matrix:
         detector:
-          - epic_arches
+          # - epic_arches
           - epic_brycecanyon
-          - epic_arches_radcor
-          - epic_brycecanyon_radcor
+          # - epic_arches_radcor
+          # - epic_brycecanyon_radcor
           - athena
           - ecce
         aname: [x_q2, p_eta, yRatio, single_bin]
         recon: [Ele]
         include: # enable other recon methods for `aname==x_q2` only
-        - { aname: x_q2, recon: Mixed,  detector: epic_arches } # FIXME: not sure how to avoid being repetitive... 
-        - { aname: x_q2, recon: JB,     detector: epic_arches }
-        - { aname: x_q2, recon: DA,     detector: epic_arches }
-        - { aname: x_q2, recon: Sigma,  detector: epic_arches }
-        - { aname: x_q2, recon: eSigma, detector: epic_arches }
+        # - { aname: x_q2, recon: Mixed,  detector: epic_arches } # FIXME: not sure how to avoid being repetitive... 
+        # - { aname: x_q2, recon: JB,     detector: epic_arches }
+        # - { aname: x_q2, recon: DA,     detector: epic_arches }
+        # - { aname: x_q2, recon: Sigma,  detector: epic_arches }
+        # - { aname: x_q2, recon: eSigma, detector: epic_arches }
         - { aname: x_q2, recon: Mixed,  detector: epic_brycecanyon }
         - { aname: x_q2, recon: JB,     detector: epic_brycecanyon }
         - { aname: x_q2, recon: DA,     detector: epic_brycecanyon }
         - { aname: x_q2, recon: Sigma,  detector: epic_brycecanyon }
         - { aname: x_q2, recon: eSigma, detector: epic_brycecanyon }
-        - { aname: x_q2, recon: Mixed,  detector: epic_arches_radcor }
-        - { aname: x_q2, recon: JB,     detector: epic_arches_radcor }
-        - { aname: x_q2, recon: DA,     detector: epic_arches_radcor }
-        - { aname: x_q2, recon: Sigma,  detector: epic_arches_radcor }
-        - { aname: x_q2, recon: eSigma, detector: epic_arches_radcor }
-        - { aname: x_q2, recon: Mixed,  detector: epic_brycecanyon_radcor }
-        - { aname: x_q2, recon: JB,     detector: epic_brycecanyon_radcor }
-        - { aname: x_q2, recon: DA,     detector: epic_brycecanyon_radcor }
-        - { aname: x_q2, recon: Sigma,  detector: epic_brycecanyon_radcor }
-        - { aname: x_q2, recon: eSigma, detector: epic_brycecanyon_radcor }
+        # - { aname: x_q2, recon: Mixed,  detector: epic_arches_radcor }
+        # - { aname: x_q2, recon: JB,     detector: epic_arches_radcor }
+        # - { aname: x_q2, recon: DA,     detector: epic_arches_radcor }
+        # - { aname: x_q2, recon: Sigma,  detector: epic_arches_radcor }
+        # - { aname: x_q2, recon: eSigma, detector: epic_arches_radcor }
+        # - { aname: x_q2, recon: Mixed,  detector: epic_brycecanyon_radcor }
+        # - { aname: x_q2, recon: JB,     detector: epic_brycecanyon_radcor }
+        # - { aname: x_q2, recon: DA,     detector: epic_brycecanyon_radcor }
+        # - { aname: x_q2, recon: Sigma,  detector: epic_brycecanyon_radcor }
+        # - { aname: x_q2, recon: eSigma, detector: epic_brycecanyon_radcor }
         - { aname: x_q2, recon: Mixed,  detector: athena }
         - { aname: x_q2, recon: JB,     detector: athena }
         - { aname: x_q2, recon: DA,     detector: athena }
@@ -359,7 +359,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        detector: [epic_arches]
+        detector: [epic_brycecanyon]
         aname: [x_q2]
         recon: [Ele]
     steps:
@@ -402,10 +402,10 @@ jobs:
       matrix:
         mode:
           - fastsim
-          - epic_arches
+          # - epic_arches
           - epic_brycecanyon
-          - epic_arches_radcor
-          - epic_brycecanyon_radcor
+          # - epic_arches_radcor
+          # - epic_brycecanyon_radcor
           - athena
           - ecce
         pname: # list only jobs which will only use one (primary) recon method
@@ -429,30 +429,30 @@ jobs:
           - { mode: fastsim,                 pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: fastsim,                 pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: fastsim,                 pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches,             pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches,             pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches,             pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches,             pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: epic_brycecanyon,        pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
-          - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_arches_radcor,      pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: JB,     aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Mixed,  aname: x_q2, pmacro: postprocess_x_q2.C }
+          # - { mode: epic_brycecanyon_radcor, pname: coverage2D_x_q2, recon: Sigma,  aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: athena,                  pname: coverage2D_x_q2, recon: Ele,    aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: athena,                  pname: coverage2D_x_q2, recon: DA,     aname: x_q2, pmacro: postprocess_x_q2.C }
           - { mode: athena,                  pname: coverage2D_x_q2, recon: eSigma, aname: x_q2, pmacro: postprocess_x_q2.C }
@@ -502,79 +502,79 @@ jobs:
 # COMPARATORS ---------------------------------------------------------------------------
 
 # run compare macros matrix for fastsim vs. fullsim
-  comparison:
-    needs:
-      - analysis_fastsim
-      - analysis_fullsim
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        pname: # list only jobs which will only use one (primary) recon method
-          - coverage_p_eta
-          - resolution_p_eta
-        recon: [Ele] # primary recon method(s)
-        include:
-          # use only primary recon method
-          - { pname: coverage_p_eta,   aname: p_eta, xvar: p, yvar: eta }
-          - { pname: resolution_p_eta, aname: p_eta, xvar: p, yvar: eta }
-          # use all reconstruction methods:
-          ## resolution
-          - { pname: resolution_x_q2, recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: resolution_x_q2, recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: resolution_x_q2, recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: resolution_x_q2, recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: resolution_x_q2, recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: resolution_x_q2, recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
-          ## coverage
-          - { pname: coverage_x_q2,   recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: coverage_x_q2,   recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: coverage_x_q2,   recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: coverage_x_q2,   recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: coverage_x_q2,   recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
-          - { pname: coverage_x_q2,   recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: x_build_no_delphes
-      - uses: actions/download-artifact@v3
-        with:
-          name: analysis
-          path: out
-      - uses: cvmfs-contrib/github-action-cvmfs@v3
-      - uses: eic/run-cvmfs-osg-eic-shell@main
-        with:
-          platform-release: "jug_xl:nightly"
-          setup: environ.sh
-          run: |
-            echo "[CI] job matrix params:"
-            echo "aname = ${{matrix.aname}}"
-            echo "pname = ${{matrix.pname}}"
-            echo "recon = ${{matrix.recon}}"
-            echo "xvar = ${{matrix.xvar}}"
-            echo "yvar = ${{matrix.yvar}}"
-            echo "[CI] COMPARATOR MACRO: ePIC"
-            macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-              'ePIC Arches (no radcor)'      'epic_arches'             \
-              'ePIC BryceCanyon (no radcor)' 'epic_brycecanyon'        \
-              'ePIC Arches (radcor)'         'epic_arches_radcor'      \
-              'ePIC BryceCanyon (radcor)'    'epic_brycecanyon_radcor' \
-              'ePIC'
-            echo "[CI] COMPARATOR MACRO: LEGACY"
-            macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
-              'Delphes Pythia6 (no radcor)' 'fastsim'     \
-              'ePIC Arches (no radcor)'     'epic_arches' \
-              'ATHENA'                      'athena'      \
-              'ECCE'                        'ecce'        \
-              'LEGACY'
-      - uses: actions/upload-artifact@v3
-        with:
-          name: comparison
-          retention-days: 30
-          path: |
-            out/comparison*.images/*.png
-            out/comparison*.root
+  # comparison:
+  #   needs:
+  #     - analysis_fastsim
+  #     - analysis_fullsim
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       pname: # list only jobs which will only use one (primary) recon method
+  #         - coverage_p_eta
+  #         - resolution_p_eta
+  #       recon: [Ele] # primary recon method(s)
+  #       include:
+  #         # use only primary recon method
+  #         - { pname: coverage_p_eta,   aname: p_eta, xvar: p, yvar: eta }
+  #         - { pname: resolution_p_eta, aname: p_eta, xvar: p, yvar: eta }
+  #         # use all reconstruction methods:
+  #         ## resolution
+  #         - { pname: resolution_x_q2, recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: resolution_x_q2, recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: resolution_x_q2, recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: resolution_x_q2, recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: resolution_x_q2, recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: resolution_x_q2, recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
+  #         ## coverage
+  #         - { pname: coverage_x_q2,   recon: Ele,    aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: coverage_x_q2,   recon: Mixed,  aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: coverage_x_q2,   recon: DA,     aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: coverage_x_q2,   recon: JB,     aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: coverage_x_q2,   recon: Sigma,  aname: x_q2, xvar: x, yvar: q2 }
+  #         - { pname: coverage_x_q2,   recon: eSigma, aname: x_q2, xvar: x, yvar: q2 }
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: x_build_no_delphes
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: analysis
+  #         path: out
+  #     - uses: cvmfs-contrib/github-action-cvmfs@v3
+  #     - uses: eic/run-cvmfs-osg-eic-shell@main
+  #       with:
+  #         platform-release: "jug_xl:nightly"
+  #         setup: environ.sh
+  #         run: |
+  #           echo "[CI] job matrix params:"
+  #           echo "aname = ${{matrix.aname}}"
+  #           echo "pname = ${{matrix.pname}}"
+  #           echo "recon = ${{matrix.recon}}"
+  #           echo "xvar = ${{matrix.xvar}}"
+  #           echo "yvar = ${{matrix.yvar}}"
+  #           echo "[CI] COMPARATOR MACRO: ePIC"
+  #           macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
+  #             'ePIC Arches (no radcor)'      'epic_arches'             \
+  #             'ePIC BryceCanyon (no radcor)' 'epic_brycecanyon'        \
+  #             'ePIC Arches (radcor)'         'epic_arches_radcor'      \
+  #             'ePIC BryceCanyon (radcor)'    'epic_brycecanyon_radcor' \
+  #             'ePIC'
+  #           echo "[CI] COMPARATOR MACRO: LEGACY"
+  #           macro/ci/comparator_run.sh ${{matrix.aname}} ${{matrix.pname}} ${{matrix.recon}} ${{matrix.xvar}} ${{matrix.yvar}} \
+  #             'Delphes Pythia6 (no radcor)' 'fastsim'     \
+  #             'ePIC Arches (no radcor)'     'epic_arches' \
+  #             'ATHENA'                      'athena'      \
+  #             'ECCE'                        'ecce'        \
+  #             'LEGACY'
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         name: comparison
+  #         retention-days: 30
+  #         path: |
+  #           out/comparison*.images/*.png
+  #           out/comparison*.root
 
 # ARTIFACTS ---------------------------------------------------------------------------
 
@@ -582,7 +582,7 @@ jobs:
   collect:
     needs: 
       - postprocess
-      - comparison
+      # - comparison
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -590,10 +590,10 @@ jobs:
         with:
           name: postprocess
           path: results
-      - uses: actions/download-artifact@v3
-        with:
-          name: comparison
-          path: results
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: comparison
+      #     path: results
       - name: tree_artifacts
         run: tree results
       - name: cull
@@ -616,11 +616,15 @@ jobs:
           tree results
       - name: merge_fastfull
         run: |
+          # macro/ci/merge-fastfull.sh results \
+          #   epic_arches             \
+          #   epic_brycecanyon        \
+          #   epic_arches_radcor      \
+          #   epic_brycecanyon_radcor \
+          #   ecce                    \
+          #   athena
           macro/ci/merge-fastfull.sh results \
-            epic_arches             \
             epic_brycecanyon        \
-            epic_arches_radcor      \
-            epic_brycecanyon_radcor \
             ecce                    \
             athena
           tree results

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -51,7 +51,7 @@ end
 # }
 prodSettings = {
   'epic.23.06.1' => {
-    :comment         => 'Pythia 8: high-stats May 2023 production',
+    :comment         => 'Pythia 8: high-stats June 2023 production',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
     :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
     :energySubDir    => Proc.new { "#{options.energy}" },

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -7,9 +7,13 @@ require 'optparse'
 require 'ostruct'
 require 'fileutils'
 
+# default versions
+VersionLatest   = 'epic.23.06.1'
+VersionPrevious = 'epic.23.05.2'
+
 # default CLI options
 options = OpenStruct.new
-options.version    = 'epic.23.06.1'
+options.version    = VersionLatest
 options.energy     = '18x275'
 options.locDir     = ''
 options.mode       = 's'
@@ -46,13 +50,6 @@ end
 #   :fileExtension   => File extension (optional, defaults to 'root')
 # }
 prodSettings = {
-  'epic.unstable' => {
-    :comment         => "Latest ePIC TEST sample production; update in #{$0} as needed",
-    :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
-    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/main/epic_brycecanyon/DIS/NC" }, # FORCE brycecanyon only
-    :energySubDir    => Proc.new { "#{options.energy}" },
-    :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
-  },
   'epic.23.06.1' => {
     :comment         => 'Pythia 8: high-stats May 2023 production',
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
@@ -170,13 +167,18 @@ OptionParser.new do |o|
        "Default: #{options.version}",
        "Choose one of the following:"
       ) do |a|
-        unless prodSettings.keys.include? a
-          $stderr.puts "ERROR: unknown DETECTOR_VERSION '#{a}'"
+        ver = a
+        ver = VersionLatest   if a == 'epic.latest'
+        ver = VersionPrevious if a == 'epic.previous'
+        unless prodSettings.keys.include? ver
+          $stderr.puts "ERROR: unknown DETECTOR_VERSION '#{ver}'"
           exit 1
         end
-        options.version = a
+        options.version = ver
       end
   o.separator ''
+  o.separator 'epic.latest'.rjust(30)   + '  ::  ' + "Latest production: #{VersionLatest}"
+  o.separator 'epic.previous'.rjust(30) + '  ::  ' + "Previous production: #{VersionPrevious}"
   prodSettings.map{ |k,v| o.separator k.rjust(30) + '  ::  ' + v[:comment] }
   o.separator ''
   o.separator ' '*20+'NOTE: if the version name starts with \'hepmc\', HEPMC files will be'
@@ -386,7 +388,6 @@ if [
 
 # pattern: "#{energy}/minQ2=#{minQ2}/"
 elsif [
-  'epic.unstable',
   'epic.23.06.1',
   'epic.23.05.2',
   'epic.23.05.1',

--- a/s3tools/s3tool.rb
+++ b/s3tools/s3tool.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 
 # default CLI options
 options = OpenStruct.new
-options.version    = 'epic.23.05.2'
+options.version    = 'epic.23.06.1'
 options.energy     = '18x275'
 options.locDir     = ''
 options.mode       = 's'
@@ -50,6 +50,13 @@ prodSettings = {
     :comment         => "Latest ePIC TEST sample production; update in #{$0} as needed",
     :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
     :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/main/epic_brycecanyon/DIS/NC" }, # FORCE brycecanyon only
+    :energySubDir    => Proc.new { "#{options.energy}" },
+    :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
+  },
+  'epic.23.06.1' => {
+    :comment         => 'Pythia 8: high-stats May 2023 production',
+    :crossSectionID  => Proc.new { |minQ2| "pythia8:#{options.energy}/minQ2=#{minQ2}" },
+    :releaseSubDir   => Proc.new { "S3/eictest/EPIC/RECO/#{versionNum(options.version)}/epic_#{options.detector}/DIS/NC" },
     :energySubDir    => Proc.new { "#{options.energy}" },
     :dataSubDir      => Proc.new { |minQ2| "minQ2=#{minQ2}" },
   },
@@ -380,6 +387,7 @@ if [
 # pattern: "#{energy}/minQ2=#{minQ2}/"
 elsif [
   'epic.unstable',
+  'epic.23.06.1',
   'epic.23.05.2',
   'epic.23.05.1',
   'epic.23.03.0_pythia8',

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -447,7 +447,7 @@ void Analysis::Prepare() {
       HS->DefineHist2D("etaVsP","p","#eta","GeV","",
           NBINS,0.1,100,
           NBINS,-4,4,
-          true,false
+          true,false,true
           );
       Double_t etabinsCoarse[] = {-4.0,-1.0,1.0,4.0};
       Double_t pbinsCoarse[] = {0.1,1,10,100};

--- a/src/PostProcessor.cxx
+++ b/src/PostProcessor.cxx
@@ -330,6 +330,7 @@ void PostProcessor::DrawSingle(TString histSet, TString histName) {
     canv->SetLogz(H->GetHistConfig(histName)->logz);
     canv->SetBottomMargin(0.15);
     canv->SetLeftMargin(0.15);
+    canv->SetRightMargin(0.15);
     canv->Print(pngDir+"/"+canvN+".png");
     outfile->cd("/");
     canv->Write();
@@ -350,6 +351,7 @@ void PostProcessor::DrawSingle(TString histSet, TString histName) {
     canv->SetLogz(H->GetHist4Config(histName)->logz);
     canv->SetBottomMargin(0.15);
     canv->SetLeftMargin(0.15);
+    canv->SetRightMargin(0.15);
     hist4->Draw();
 
     canv->Print(pngDir+"/"+canvN+".png");

--- a/src/PostProcessor.cxx
+++ b/src/PostProcessor.cxx
@@ -242,6 +242,7 @@ void PostProcessor::DrawSingle(Histos *H, TString histName, TString drawFormat, 
   canv->SetLogz(H->GetHistConfig(histName)->logz);
   canv->SetBottomMargin(0.15);
   canv->SetLeftMargin(0.15);
+  canv->SetRightMargin(0.15);
 
   // profile for 2D plot
   if(profileAxis>0 && hist->GetDimension()==2) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- Support production 23.06.1
- Set eta vs. p plot to log scale (for PID review)
- CI: change ePIC `arches` vs. `brycecanyon` comparisons to be `latest` production vs. `previous` production
  - `latest` and `previous` is set in `s3tool.rb`
  - disable legacy comparisons
  - this was motivated by `brycecanyon` now being the primary focus for productions

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
yes, new default production